### PR TITLE
debezium/dbz#1245 Add description field to connections API payload

### DIFF
--- a/debezium-platform-conductor/src/main/java/io/debezium/platform/api/dto/ConnectionRequest.java
+++ b/debezium-platform-conductor/src/main/java/io/debezium/platform/api/dto/ConnectionRequest.java
@@ -14,6 +14,7 @@ import io.debezium.platform.data.model.ConnectionEntity;
 
 public record ConnectionRequest(
         @NotEmpty String name,
+        String description,
         @NotNull ConnectionEntity.Type type,
         Map<String, Object> config) {
 }

--- a/debezium-platform-conductor/src/main/java/io/debezium/platform/api/dto/ConnectionResponse.java
+++ b/debezium-platform-conductor/src/main/java/io/debezium/platform/api/dto/ConnectionResponse.java
@@ -12,6 +12,7 @@ import io.debezium.platform.data.model.ConnectionEntity;
 public record ConnectionResponse(
         Long id,
         String name,
+        String description,
         ConnectionEntity.Type type,
         Map<String, Object> config) {
 }

--- a/debezium-platform-conductor/src/main/java/io/debezium/platform/data/model/ConnectionEntity.java
+++ b/debezium-platform-conductor/src/main/java/io/debezium/platform/data/model/ConnectionEntity.java
@@ -31,6 +31,8 @@ public class ConnectionEntity {
     @Column(unique = true, nullable = false)
     private String name;
 
+    private String description;
+
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private Type type;
@@ -88,6 +90,14 @@ public class ConnectionEntity {
 
     public void setName(String name) {
         this.name = name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
     }
 
     public Type getType() {

--- a/debezium-platform-conductor/src/main/java/io/debezium/platform/domain/views/Connection.java
+++ b/debezium-platform-conductor/src/main/java/io/debezium/platform/domain/views/Connection.java
@@ -22,6 +22,10 @@ public interface Connection extends NamedView {
 
     void setName(String name);
 
+    String getDescription();
+
+    void setDescription(String description);
+
     ConnectionEntity.Type getType();
 
     void setType(ConnectionEntity.Type type);

--- a/debezium-platform-conductor/src/main/resources/db/migration/V3.7.0.1__add_connection_description.sql
+++ b/debezium-platform-conductor/src/main/resources/db/migration/V3.7.0.1__add_connection_description.sql
@@ -1,0 +1,2 @@
+-- DBZ-1245 Add description field to connection table
+alter table if exists connection add column description varchar(255);

--- a/debezium-platform-conductor/src/test/java/io/debezium/platform/api/ConnectionResourceIT.java
+++ b/debezium-platform-conductor/src/test/java/io/debezium/platform/api/ConnectionResourceIT.java
@@ -8,6 +8,7 @@ package io.debezium.platform.api;
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.Matchers.hasItem;
 
 import org.junit.jupiter.api.Test;
@@ -22,6 +23,7 @@ public class ConnectionResourceIT {
         return """
                 {
                   "name": "test-connection-%s",
+                  "description": "Test connection description",
                   "type": "POSTGRESQL",
                   "config": {
                     "host": "localhost",
@@ -38,6 +40,7 @@ public class ConnectionResourceIT {
                 {
                   "id": %d,
                   "name": "updated-connection-%s",
+                  "description": "Updated connection description",
                   "type": "POSTGRESQL",
                   "config": {
                     "host": "updated-host",
@@ -75,10 +78,45 @@ public class ConnectionResourceIT {
                 .header("Location", notNullValue())
                 .body("id", notNullValue())
                 .body("name", is("test-connection-" + nameSuffix))
+                .body("description", is("Test connection description"))
                 .body("type", is("POSTGRESQL"))
                 .body("config.host", is("localhost"))
                 .body("config.port", is(5432))
                 .body("config.username", is("testuser"));
+    }
+
+    @Test
+    public void testCreateConnection_WithoutDescription() {
+        String nameSuffix = String.valueOf(System.currentTimeMillis());
+        String json = """
+                {
+                  "name": "test-connection-no-desc-%s",
+                  "type": "POSTGRESQL",
+                  "config": {
+                    "host": "localhost",
+                    "port": 5432,
+                    "username": "testuser",
+                    "password": "testpass"
+                  }
+                }
+                """.formatted(nameSuffix);
+
+        Integer connectionId = given()
+                .contentType(ContentType.JSON)
+                .body(json)
+                .when()
+                .post("api/connections")
+                .then()
+                .statusCode(201)
+                .contentType(ContentType.JSON)
+                .body("id", notNullValue())
+                .body("name", is("test-connection-no-desc-" + nameSuffix))
+                .body("description", nullValue())
+                .body("type", is("POSTGRESQL"))
+                .extract()
+                .path("id");
+
+        cleanUp(connectionId);
     }
 
     @Test
@@ -104,6 +142,7 @@ public class ConnectionResourceIT {
                 .statusCode(200)
                 .body("id", is(connectionId.intValue()))
                 .body("name", is("test-connection-" + nameSuffix))
+                .body("description", is("Test connection description"))
                 .body("type", is("POSTGRESQL"))
                 .body("config.host", is("localhost"))
                 .body("config.port", is(5432))
@@ -150,6 +189,7 @@ public class ConnectionResourceIT {
                 .statusCode(200)
                 .body("id", is(connectionId.intValue()))
                 .body("name", is("updated-connection-" + updatedNameSuffix))
+                .body("description", is("Updated connection description"))
                 .body("config.host", is("updated-host"))
                 .body("config.port", is(5433))
                 .body("config.username", is("updateduser"));

--- a/debezium-platform-conductor/src/test/java/io/debezium/platform/environment/connection/TestConnectionView.java
+++ b/debezium-platform-conductor/src/test/java/io/debezium/platform/environment/connection/TestConnectionView.java
@@ -36,6 +36,16 @@ public class TestConnectionView implements Connection {
     }
 
     @Override
+    public String getDescription() {
+        return null;
+    }
+
+    @Override
+    public void setDescription(String description) {
+
+    }
+
+    @Override
     public void setType(ConnectionEntity.Type type) {
 
     }

--- a/debezium-platform-stage/src/__mocks__/data/Connections.json
+++ b/debezium-platform-stage/src/__mocks__/data/Connections.json
@@ -9,6 +9,7 @@
             "username": "debezium",
             "additional-key": "additional-val"
         },
+        "description": "MariaDB connection for testing",
         "name": "mariaconnection",
         "type": "MARIADB"
     },
@@ -17,6 +18,7 @@
         "config": {
             "test-value": "test-key"
         },
+        "description": "Kinesis connection for streaming",
         "name": "kinesis-connection",
         "type": "AMAZON_KINESIS"
     }

--- a/debezium-platform-stage/src/apis/apis.tsx
+++ b/debezium-platform-stage/src/apis/apis.tsx
@@ -87,6 +87,7 @@ export type ConnectionPayload = {
   type: string;
   id?: string;
   config: ConnectionUnknownConfig | ConnectionAdditionalConfig;
+  description?: string;
   name: string;
 };
 
@@ -132,6 +133,7 @@ export type ConnectionSchema = {
 export type Connection = {
   type: string;
   config: ConnectionUnknownConfig;
+  description?: string;
   name: string;
   id: number;
 };


### PR DESCRIPTION
## Summary

Adds the `description` field to the connections API payload, consistent with all other resources (pipelines, sources, destinations, transforms, vaults) that already have this field.

Closes debezium/dbz#1245

## Changes

**Backend (Java/Quarkus):**
- `ConnectionEntity.java`: Added `description` field with getter/setter
- `Connection.java` (Blaze-Persistence EntityView): Added `getDescription()`/`setDescription()`
- New Flyway migration `V3.5.0__add_connection_description.sql`: Adds `description varchar(255)` column to `connection` table

**Frontend (TypeScript/React):**
- `apis.tsx`: Added `description?: string` to `Connection` and `ConnectionPayload` types
- `Connections.json`: Updated mock data with description field

**Tests:**
- `ConnectionResourceIT.java`: Updated test payloads to include description, added assertions, added `testCreateConnection_WithoutDescription` to verify optionality

## Design Decisions
- Description is optional (nullable), consistent with all other entities
- No REST endpoint changes needed — Blaze-Persistence and Jackson handle serialization automatically
- Column type `varchar(255)` matches existing description columns in other tables