### PR TITLE
debezium/dbz#1097 Add support for connection validator for Milvus

### DIFF
--- a/debezium-platform-conductor/pom.xml
+++ b/debezium-platform-conductor/pom.xml
@@ -55,6 +55,7 @@
         <version.nats>2.25.2</version.nats>
         <version.oras>0.3.1</version.oras>
         <version.rabbitmq>5.29.0</version.rabbitmq>
+        <version.milvus>2.6.4</version.milvus>
 
         <format.formatter.goal>format</format.formatter.goal>
         <format.imports.goal>sort</format.imports.goal>
@@ -456,7 +457,7 @@
         <dependency>
             <groupId>io.milvus</groupId>
             <artifactId>milvus-sdk-java</artifactId>
-            <version>2.6.4</version>
+            <version>${version.milvus}</version>
         </dependency>
 
         <dependency>

--- a/debezium-platform-conductor/pom.xml
+++ b/debezium-platform-conductor/pom.xml
@@ -454,6 +454,12 @@
         </dependency>
 
         <dependency>
+            <groupId>io.milvus</groupId>
+            <artifactId>milvus-sdk-java</artifactId>
+            <version>2.6.4</version>
+        </dependency>
+
+        <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-opentelemetry</artifactId>
         </dependency>

--- a/debezium-platform-conductor/pom.xml
+++ b/debezium-platform-conductor/pom.xml
@@ -674,6 +674,18 @@
         </dependency>
 
         <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-test-common</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
             <scope>test</scope>

--- a/debezium-platform-conductor/pom.xml
+++ b/debezium-platform-conductor/pom.xml
@@ -674,18 +674,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.testcontainers</groupId>
-            <artifactId>testcontainers</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-test-common</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
             <scope>test</scope>

--- a/debezium-platform-conductor/pom.xml
+++ b/debezium-platform-conductor/pom.xml
@@ -642,18 +642,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.testcontainers</groupId>
-            <artifactId>testcontainers</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-test-common</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
             <scope>test</scope>

--- a/debezium-platform-conductor/pom.xml
+++ b/debezium-platform-conductor/pom.xml
@@ -441,6 +441,12 @@
         </dependency>
 
         <dependency>
+            <groupId>io.milvus</groupId>
+            <artifactId>milvus-sdk-java</artifactId>
+            <version>2.6.4</version>
+        </dependency>
+
+        <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-opentelemetry</artifactId>
         </dependency>

--- a/debezium-platform-conductor/pom.xml
+++ b/debezium-platform-conductor/pom.xml
@@ -54,6 +54,7 @@
         <version.nats>2.17.6</version.nats>
         <version.oras>0.3.1</version.oras>
         <version.rabbitmq>5.20.0</version.rabbitmq>
+        <version.milvus>2.6.4</version.milvus>
 
         <format.formatter.goal>format</format.formatter.goal>
         <format.imports.goal>sort</format.imports.goal>
@@ -443,7 +444,7 @@
         <dependency>
             <groupId>io.milvus</groupId>
             <artifactId>milvus-sdk-java</artifactId>
-            <version>2.6.4</version>
+            <version>${version.milvus}</version>
         </dependency>
 
         <dependency>

--- a/debezium-platform-conductor/pom.xml
+++ b/debezium-platform-conductor/pom.xml
@@ -642,6 +642,18 @@
         </dependency>
 
         <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-test-common</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
             <scope>test</scope>

--- a/debezium-platform-conductor/src/main/java/io/debezium/platform/environment/connection/destination/MilvusConnectionValidator.java
+++ b/debezium-platform-conductor/src/main/java/io/debezium/platform/environment/connection/destination/MilvusConnectionValidator.java
@@ -1,0 +1,212 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.platform.environment.connection.destination;
+
+import java.util.Map;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Named;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.debezium.platform.data.dto.ConnectionValidationResult;
+import io.debezium.platform.domain.views.Connection;
+import io.debezium.platform.environment.connection.ConnectionValidator;
+import io.milvus.v2.client.ConnectConfig;
+import io.milvus.v2.client.MilvusClientV2;
+
+/**
+ * Implementation of {@link ConnectionValidator} for Milvus vector database connections.
+ * <p>
+ * This validator performs validation of Milvus connection configurations
+ * including network connectivity, authentication, and database accessibility.
+ * </p>
+ *
+ * <p>
+ * The validation process includes:
+ * <ul>
+ *   <li>Connection parameter validation (host, port, database)</li>
+ *   <li>Client connection establishment</li>
+ *   <li>Authentication verification if credentials are provided</li>
+ *   <li>Basic database operation to confirm connectivity</li>
+ *   <li>Timeout handling for network issues</li>
+ * </ul>
+ * </p>
+ *
+ * @author Pranav Tiwari
+ */
+@ApplicationScoped
+@Named("MILVUS")
+public class MilvusConnectionValidator implements ConnectionValidator {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(MilvusConnectionValidator.class);
+
+    private final int defaultConnectionTimeout;
+
+    private static final String URI_KEY = "uri";
+    private static final String DATABASE_KEY = "database";
+    private static final String USERNAME_KEY = "username";
+    private static final String PASSWORD_KEY = "password";
+    private static final String TOKEN_KEY = "token";
+
+    public MilvusConnectionValidator(@ConfigProperty(name = "destinations.milvus.connection.timeout") int defaultConnectionTimeout) {
+        this.defaultConnectionTimeout = defaultConnectionTimeout;
+    }
+
+    @Override
+    public ConnectionValidationResult validate(Connection connectionConfig) {
+        if (connectionConfig == null) {
+            return ConnectionValidationResult.failed("Connection configuration cannot be null");
+        }
+
+        try {
+            LOGGER.debug("Starting Milvus connection validation for connection: {}", connectionConfig.getName());
+
+            Map<String, Object> milvusConfig = connectionConfig.getConfig();
+
+            // Validate required configuration parameters
+            ConnectionValidationResult configValidation = validateConfiguration(milvusConfig);
+            if (!configValidation.valid()) {
+                return configValidation;
+            }
+
+            return performConnectionValidation(milvusConfig);
+
+        }
+        catch (Exception e) {
+            LOGGER.error("Unexpected error during Milvus connection validation", e);
+            return ConnectionValidationResult.failed("Validation failed due to unexpected error: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Validates the required Milvus configuration parameters.
+     *
+     * @param milvusConfig the Milvus configuration properties
+     * @return ConnectionValidationResult indicating parameter validation result
+     */
+    private ConnectionValidationResult validateConfiguration(Map<String, Object> milvusConfig) {
+        if (!milvusConfig.containsKey(URI_KEY) ||
+                milvusConfig.get(URI_KEY) == null ||
+                milvusConfig.get(URI_KEY).toString().trim().isEmpty()) {
+            return ConnectionValidationResult.failed("URI must be specified");
+        }
+
+        // Validate URI format
+        String uri = milvusConfig.get(URI_KEY).toString().trim();
+        if (!uri.startsWith("http://") && !uri.startsWith("https://")) {
+            return ConnectionValidationResult.failed("URI must start with http:// or https://");
+        }
+
+        return ConnectionValidationResult.successful();
+    }
+
+    /**
+     * Performs the actual connection validation by attempting to connect to Milvus
+     * using the official Milvus V2 SDK client.
+     *
+     * @param milvusConfig the Milvus configuration properties
+     * @return ConnectionValidationResult indicating success or failure
+     */
+    private ConnectionValidationResult performConnectionValidation(Map<String, Object> milvusConfig) {
+        MilvusClientV2 milvusClient = null;
+
+        try {
+            LOGGER.debug("Creating Milvus V2 client for validation");
+
+            // Use the provided URI directly
+            String uri = milvusConfig.get(URI_KEY).toString().trim();
+            LOGGER.debug("Attempting to connect to Milvus at: {}", uri);
+
+            // Build connection configuration using the official API
+            var configBuilder = ConnectConfig.builder()
+                    .uri(uri)
+                    .rpcDeadlineMs(defaultConnectionTimeout * 1000L); // Convert seconds to milliseconds
+
+            // Add database if specified
+            if (milvusConfig.containsKey(DATABASE_KEY) && milvusConfig.get(DATABASE_KEY) != null
+                    && !milvusConfig.get(DATABASE_KEY).toString().trim().isEmpty()) {
+                configBuilder.dbName(milvusConfig.get(DATABASE_KEY).toString());
+                LOGGER.debug("Using database: {}", milvusConfig.get(DATABASE_KEY).toString());
+            }
+
+            // Add authentication if provided
+            if (milvusConfig.containsKey(TOKEN_KEY) && milvusConfig.get(TOKEN_KEY) != null
+                    && !milvusConfig.get(TOKEN_KEY).toString().trim().isEmpty()) {
+                // Token format: "username:password"
+                configBuilder.token(milvusConfig.get(TOKEN_KEY).toString());
+                LOGGER.debug("Using token authentication");
+            }
+            else if (milvusConfig.containsKey(USERNAME_KEY) && milvusConfig.get(USERNAME_KEY) != null
+                    && milvusConfig.containsKey(PASSWORD_KEY) && milvusConfig.get(PASSWORD_KEY) != null) {
+                // Separate username and password
+                configBuilder.username(milvusConfig.get(USERNAME_KEY).toString())
+                        .password(milvusConfig.get(PASSWORD_KEY).toString());
+                LOGGER.debug("Using username/password authentication for user: {}", milvusConfig.get(USERNAME_KEY).toString());
+            }
+
+            // Create client with the configuration
+            milvusClient = new MilvusClientV2(configBuilder.build());
+
+            LOGGER.debug("Successfully created Milvus client, performing basic validation");
+
+            // Perform a simple operation to verify the connection works
+            // Using listDatabases() as a lightweight operation to test connectivity
+            var databases = milvusClient.listDatabases();
+            LOGGER.debug("Successfully validated Milvus connection. Available databases: {}", databases.getDatabaseNames().size());
+
+            return ConnectionValidationResult.successful();
+
+        }
+        catch (Exception e) {
+            LOGGER.warn("Failed to connect to Milvus server", e);
+
+            String errorMessage = e.getMessage();
+            if (errorMessage == null) {
+                errorMessage = e.getClass().getSimpleName();
+            }
+
+            // Handle specific error types with user-friendly messages
+            if (errorMessage.contains("timeout") || errorMessage.contains("TimeoutException") ||
+                    errorMessage.contains("deadline")) {
+                return ConnectionValidationResult.failed(
+                        "Connection timeout - please check host, port and network connectivity");
+            }
+            else if (errorMessage.contains("authentication") || errorMessage.contains("auth") ||
+                    errorMessage.contains("permission") || errorMessage.contains("credentials") ||
+                    errorMessage.contains("Unauthenticated")) {
+                return ConnectionValidationResult.failed(
+                        "Authentication failed - please check username, password, or token");
+            }
+            else if (errorMessage.contains("connect") || errorMessage.contains("refused") ||
+                    errorMessage.contains("unreachable") || errorMessage.contains("UNAVAILABLE")) {
+                return ConnectionValidationResult.failed(
+                        "Cannot connect to Milvus server - please check host and port configuration");
+            }
+            else if (errorMessage.contains("database") && errorMessage.contains("not found")) {
+                return ConnectionValidationResult.failed(
+                        "Specified database does not exist - please check database name");
+            }
+            else {
+                return ConnectionValidationResult.failed("Failed to connect to Milvus: " + errorMessage);
+            }
+
+        }
+        finally {
+            if (milvusClient != null) {
+                try {
+                    LOGGER.debug("Closing Milvus client");
+                    milvusClient.close();
+                }
+                catch (Exception e) {
+                    LOGGER.warn("Error closing Milvus client", e);
+                }
+            }
+        }
+    }
+}

--- a/debezium-platform-conductor/src/main/java/io/debezium/platform/environment/connection/destination/MilvusConnectionValidator.java
+++ b/debezium-platform-conductor/src/main/java/io/debezium/platform/environment/connection/destination/MilvusConnectionValidator.java
@@ -37,7 +37,6 @@ import io.milvus.v2.client.MilvusClientV2;
  *   <li>Timeout handling for network issues</li>
  * </ul>
  * </p>
- *
  */
 @ApplicationScoped
 @Named("MILVUS")
@@ -98,8 +97,8 @@ public class MilvusConnectionValidator implements ConnectionValidator {
 
         // Validate URI format
         String uri = milvusConfig.get(URI_KEY).toString().trim();
-        if (!uri.startsWith("http://") && !uri.startsWith("https://")) {
-            return ConnectionValidationResult.failed("URI must start with http:// or https://");
+        if (!uri.startsWith("http://") && !uri.startsWith("https://") && !uri.startsWith("grpc://")) {
+            return ConnectionValidationResult.failed("URI must start with http://, https://, or grpc://");
         }
 
         return ConnectionValidationResult.successful();
@@ -170,30 +169,28 @@ public class MilvusConnectionValidator implements ConnectionValidator {
                 errorMessage = e.getClass().getSimpleName();
             }
 
-            // Handle specific error types with user-friendly messages
             if (errorMessage.contains("timeout") || errorMessage.contains("TimeoutException") ||
                     errorMessage.contains("deadline")) {
                 return ConnectionValidationResult.failed(
                         "Connection timeout - please check host, port and network connectivity");
             }
-            else if (errorMessage.contains("authentication") || errorMessage.contains("auth") ||
+            if (errorMessage.contains("authentication") || errorMessage.contains("auth") ||
                     errorMessage.contains("permission") || errorMessage.contains("credentials") ||
                     errorMessage.contains("Unauthenticated")) {
                 return ConnectionValidationResult.failed(
                         "Authentication failed - please check username, password, or token");
             }
-            else if (errorMessage.contains("connect") || errorMessage.contains("refused") ||
+            if (errorMessage.contains("connect") || errorMessage.contains("refused") ||
                     errorMessage.contains("unreachable") || errorMessage.contains("UNAVAILABLE")) {
                 return ConnectionValidationResult.failed(
                         "Cannot connect to Milvus server - please check host and port configuration");
             }
-            else if (errorMessage.contains("database") && errorMessage.contains("not found")) {
+            if (errorMessage.contains("database") && errorMessage.contains("not found")) {
                 return ConnectionValidationResult.failed(
                         "Specified database does not exist - please check database name");
             }
-            else {
-                return ConnectionValidationResult.failed("Failed to connect to Milvus: " + errorMessage);
-            }
+
+            return ConnectionValidationResult.failed("Failed to connect to Milvus: " + errorMessage);
 
         }
         finally {

--- a/debezium-platform-conductor/src/main/java/io/debezium/platform/environment/connection/destination/MilvusConnectionValidator.java
+++ b/debezium-platform-conductor/src/main/java/io/debezium/platform/environment/connection/destination/MilvusConnectionValidator.java
@@ -38,7 +38,6 @@ import io.milvus.v2.client.MilvusClientV2;
  * </ul>
  * </p>
  *
- * @author Pranav Tiwari
  */
 @ApplicationScoped
 @Named("MILVUS")

--- a/debezium-platform-conductor/src/main/java/io/debezium/platform/environment/database/MilvusTestResource.java
+++ b/debezium-platform-conductor/src/main/java/io/debezium/platform/environment/database/MilvusTestResource.java
@@ -28,7 +28,6 @@ import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
  * </ul>
  * </p>
  *
- * @author Pranav Tiwari
  */
 public class MilvusTestResource implements QuarkusTestResourceLifecycleManager {
 

--- a/debezium-platform-conductor/src/main/java/io/debezium/platform/environment/database/MilvusTestResource.java
+++ b/debezium-platform-conductor/src/main/java/io/debezium/platform/environment/database/MilvusTestResource.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.platform.environment.database;
+
+import java.util.Map;
+
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.utility.DockerImageName;
+
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
+
+/**
+ * Test resource for Milvus vector database using Testcontainers.
+ *
+ * <p>This class provides a containerized Milvus instance WITHOUT authentication
+ * for integration testing. It manages the lifecycle of a Docker container running
+ * Milvus server in standalone mode, making it suitable for testing basic
+ * connection validation scenarios.</p>
+ *
+ * <p>The Milvus instance is configured with:
+ * <ul>
+ *   <li>Default port 19530 mapped to a random host port</li>
+ *   <li>No authentication required</li>
+ *   <li>Standalone mode (single-node deployment)</li>
+ * </ul>
+ * </p>
+ *
+ * @author Pranav Tiwari
+ */
+public class MilvusTestResource implements QuarkusTestResourceLifecycleManager {
+
+    private static final String MILVUS_IMAGE = "milvusdb/milvus:latest";
+    private static final int MILVUS_PORT = 19530;
+
+    private static GenericContainer<?> milvusContainer;
+
+    @Override
+    public Map<String, String> start() {
+        milvusContainer = new GenericContainer<>(DockerImageName.parse(MILVUS_IMAGE))
+                .withExposedPorts(MILVUS_PORT)
+                .withCommand("milvus", "run", "standalone")
+                .withEnv("ETCD_USE_EMBED", "true")
+                .withEnv("COMMON_STORAGETYPE", "local");
+
+        milvusContainer.start();
+
+        return Map.of(
+                "milvus.host", milvusContainer.getHost(),
+                "milvus.port", milvusContainer.getMappedPort(MILVUS_PORT).toString());
+    }
+
+    @Override
+    public void stop() {
+        if (milvusContainer != null) {
+            milvusContainer.stop();
+        }
+    }
+
+    public static GenericContainer<?> getContainer() {
+        return milvusContainer;
+    }
+}

--- a/debezium-platform-conductor/src/main/resources/application.yml
+++ b/debezium-platform-conductor/src/main/resources/application.yml
@@ -102,6 +102,10 @@ destinations:
   qdrant:
     connection:
       timeout: 60
+  milvus:
+    connection:
+      timeout: 60
+      
 quarkus:
   smallrye-openapi:
     store-schema-directory: ../openapi

--- a/debezium-platform-conductor/src/main/resources/application.yml
+++ b/debezium-platform-conductor/src/main/resources/application.yml
@@ -99,6 +99,10 @@ destinations:
   qdrant:
     connection:
       timeout: 60
+  milvus:
+    connection:
+      timeout: 60
+      
 quarkus:
   hibernate-orm:
     mapping:

--- a/debezium-platform-conductor/src/main/resources/connection-schemas.json
+++ b/debezium-platform-conductor/src/main/resources/connection-schemas.json
@@ -605,5 +605,41 @@
         }
       }
     }
+  },
+  {
+    "type": "MILVUS",
+    "schema": {
+      "title": "Milvus connection properties",
+      "description": "Milvus connection properties",
+      "type": "object",
+      "required": [
+        "uri"
+      ],
+      "additionalProperties": {
+        "type": "string"
+      },
+      "properties": {
+        "uri": {
+          "type": "string",
+          "title": "Milvus endpoint URI (for example http://localhost:19530)"
+        },
+        "database": {
+          "type": "string",
+          "title": "Milvus database name (optional)"
+        },
+        "token": {
+          "type": "string",
+          "title": "Authentication token (optional, alternative to username/password)"
+        },
+        "username": {
+          "type": "string",
+          "title": "Username for authentication (optional, use with password)"
+        },
+        "password": {
+          "type": "string",
+          "title": "Password for authentication (optional, use with username)"
+        }
+      }
+    }
   }
 ]

--- a/debezium-platform-conductor/src/main/resources/connection-schemas.json
+++ b/debezium-platform-conductor/src/main/resources/connection-schemas.json
@@ -580,5 +580,41 @@
         }
       }
     }
+  },
+  {
+    "type": "MILVUS",
+    "schema": {
+      "title": "Milvus connection properties",
+      "description": "Milvus connection properties",
+      "type": "object",
+      "required": [
+        "uri"
+      ],
+      "additionalProperties": {
+        "type": "string"
+      },
+      "properties": {
+        "uri": {
+          "type": "string",
+          "title": "Milvus endpoint URI (for example http://localhost:19530)"
+        },
+        "database": {
+          "type": "string",
+          "title": "Milvus database name (optional)"
+        },
+        "token": {
+          "type": "string",
+          "title": "Authentication token (optional, alternative to username/password)"
+        },
+        "username": {
+          "type": "string",
+          "title": "Username for authentication (optional, use with password)"
+        },
+        "password": {
+          "type": "string",
+          "title": "Password for authentication (optional, use with username)"
+        }
+      }
+    }
   }
 ]

--- a/debezium-platform-conductor/src/test/java/io/debezium/platform/api/ConnectionSchemasResourceIT.java
+++ b/debezium-platform-conductor/src/test/java/io/debezium/platform/api/ConnectionSchemasResourceIT.java
@@ -12,6 +12,7 @@ import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.notNullValue;
 
 import java.util.Arrays;
 import java.util.List;
@@ -98,6 +99,22 @@ class ConnectionSchemasResourceIT {
                 .body("[0].schema.title", equalTo("PostgreSQL connection properties"))
                 .body("[0].schema.description", equalTo("PostgreSQL connection properties"))
                 .body("[0].schema.type", equalTo("object"));
+    }
+
+    @Test
+    void shouldContainMilvusSchema() {
+
+        given()
+                .when()
+                .get("/api/connections/schemas")
+                .then()
+                .statusCode(200)
+                .contentType(ContentType.JSON)
+                .body("find { it.type == 'MILVUS' }", notNullValue())
+                .body("find { it.type == 'MILVUS' }.schema.required", hasItems("uri"))
+                .body("find { it.type == 'MILVUS' }.schema.properties", hasKey("uri"))
+                .body("find { it.type == 'MILVUS' }.schema.properties", hasKey("database"))
+                .body("find { it.type == 'MILVUS' }.schema.properties.uri.type", equalTo("string"));
     }
 
     /*

--- a/debezium-platform-conductor/src/test/java/io/debezium/platform/environment/connection/MilvusConnectionValidatorAuthenticatedIT.java
+++ b/debezium-platform-conductor/src/test/java/io/debezium/platform/environment/connection/MilvusConnectionValidatorAuthenticatedIT.java
@@ -28,22 +28,22 @@ import io.debezium.platform.data.dto.ConnectionValidationResult;
 import io.debezium.platform.data.model.ConnectionEntity;
 import io.debezium.platform.domain.views.Connection;
 import io.debezium.platform.environment.connection.destination.MilvusConnectionValidator;
-import io.debezium.platform.environment.database.db.MilvusTestResource;
+import io.debezium.platform.environment.database.db.MilvusTestResourceAuthenticated;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 
 /**
- * Integration tests for {@link MilvusConnectionValidator} without authentication.
+ * Integration tests for {@link MilvusConnectionValidator} with authentication enabled.
  * <p>
- * These tests use a real Milvus container (via Testcontainers) to verify
- * connection validation against an actual Milvus instance without authentication.
- * Authenticated scenarios are covered by {@link MilvusConnectionValidatorAuthenticatedIT}.
+ * These tests use a real Milvus container (via Testcontainers) with authorization
+ * enabled to verify connection validation for username/password and token based
+ * authentication, including rejection of invalid credentials.
  * </p>
  *
  */
 @QuarkusTest
-@QuarkusTestResource(value = MilvusTestResource.class, restrictToAnnotatedClass = true)
-class MilvusConnectionValidatorIT {
+@QuarkusTestResource(value = MilvusTestResourceAuthenticated.class, restrictToAnnotatedClass = true)
+class MilvusConnectionValidatorAuthenticatedIT {
 
     @BeforeAll
     static void checkDockerAvailable() {
@@ -72,89 +72,82 @@ class MilvusConnectionValidatorIT {
                 });
     }
 
-    @Test
-    @DisplayName("Should successfully connect to Milvus without authentication")
-    void shouldConnectWithoutAuth() {
-        GenericContainer<?> container = MilvusTestResource.getContainer();
+    private static String containerUri() {
+        GenericContainer<?> container = MilvusTestResourceAuthenticated.getContainer();
 
         awaitPortOpen(container, 19530);
 
-        String uri = String.format("grpc://%s:%d",
+        return String.format("grpc://%s:%d",
                 container.getHost(),
                 container.getMappedPort(19530));
-
-        Connection connectionConfig = new TestConnectionView(ConnectionEntity.Type.MILVUS, Map.of(
-                "uri", uri));
-
-        ConnectionValidationResult result = connectionValidator.validate(connectionConfig);
-
-        assertTrue(result.valid(), "Connection validation should succeed");
-        assertThat(result.message()).doesNotContainIgnoringCase("error", "fail", "invalid");
     }
 
     @Test
-    @DisplayName("Should successfully connect with database parameter")
-    void shouldConnectWithDatabase() {
-        GenericContainer<?> container = MilvusTestResource.getContainer();
-
-        awaitPortOpen(container, 19530);
-
-        String uri = String.format("grpc://%s:%d",
-                container.getHost(),
-                container.getMappedPort(19530));
-
+    @DisplayName("Should successfully connect with username and password authentication")
+    void shouldConnectWithUsernamePassword() {
         Connection connectionConfig = new TestConnectionView(ConnectionEntity.Type.MILVUS, Map.of(
-                "uri", uri,
-                "database", "default"));
+                "uri", containerUri(),
+                "username", MilvusTestResourceAuthenticated.USERNAME,
+                "password", MilvusTestResourceAuthenticated.PASSWORD));
 
         ConnectionValidationResult result = connectionValidator.validate(connectionConfig);
 
-        assertTrue(result.valid(), "Connection validation with database should succeed");
-        assertThat(result.message()).doesNotContainIgnoringCase("error", "fail", "invalid");
+        assertTrue(result.valid(), "Connection validation with username and password should succeed");
+        assertThat(result.message()).doesNotContainIgnoringCase("error", "fail", "invalid", "authentication");
     }
 
     @Test
-    @DisplayName("Should fail with invalid host")
-    void shouldFailWithInvalidHost() {
+    @DisplayName("Should successfully connect with token authentication")
+    void shouldConnectWithTokenAuth() {
         Connection connectionConfig = new TestConnectionView(ConnectionEntity.Type.MILVUS, Map.of(
-                "uri", "grpc://invalid-host-12345:19530"));
+                "uri", containerUri(),
+                "token", MilvusTestResourceAuthenticated.USERNAME + ":" + MilvusTestResourceAuthenticated.PASSWORD));
 
         ConnectionValidationResult result = connectionValidator.validate(connectionConfig);
 
-        assertFalse(result.valid(), "Connection validation should fail");
-        assertThat(result.message()).containsAnyOf("connect", "UNAVAILABLE", "unreachable", "timeout");
+        assertTrue(result.valid(), "Connection validation with token authentication should succeed");
+        assertThat(result.message()).doesNotContainIgnoringCase("error", "fail", "invalid", "authentication");
     }
 
     @Test
-    @DisplayName("Should fail with invalid port")
-    void shouldFailWithInvalidPort() {
-        GenericContainer<?> container = MilvusTestResource.getContainer();
-
-        awaitPortOpen(container, 19530);
-
-        String uri = String.format("grpc://%s:%d",
-                container.getHost(),
-                99999); // Invalid port
-
+    @DisplayName("Should fail with invalid username and password")
+    void shouldFailWithInvalidCredentials() {
         Connection connectionConfig = new TestConnectionView(ConnectionEntity.Type.MILVUS, Map.of(
-                "uri", uri));
+                "uri", containerUri(),
+                "username", MilvusTestResourceAuthenticated.USERNAME,
+                "password", "wrongpassword"));
 
         ConnectionValidationResult result = connectionValidator.validate(connectionConfig);
 
-        assertFalse(result.valid(), "Connection validation should fail");
-        assertThat(result.message()).containsAnyOf("connect", "refused", "UNAVAILABLE");
+        assertFalse(result.valid(), "Connection validation with invalid credentials should fail");
+        assertThat(result.message()).containsIgnoringCase("auth");
     }
 
     @Test
-    @DisplayName("Should handle timeout gracefully")
-    void shouldHandleTimeout() {
-        // Use a non-routable IP address to simulate timeout
+    @DisplayName("Should fail with invalid token")
+    void shouldFailWithInvalidToken() {
         Connection connectionConfig = new TestConnectionView(ConnectionEntity.Type.MILVUS, Map.of(
-                "uri", "grpc://10.255.255.1:19530"));
+                "uri", containerUri(),
+                "token", MilvusTestResourceAuthenticated.USERNAME + ":invalidtoken"));
 
         ConnectionValidationResult result = connectionValidator.validate(connectionConfig);
 
-        assertFalse(result.valid(), "Connection validation should fail");
-        assertThat(result.message()).containsAnyOf("timeout", "connect", "Connection timeout");
+        assertFalse(result.valid(), "Connection validation with invalid token should fail");
+        assertThat(result.message()).containsIgnoringCase("auth");
+    }
+
+    @Test
+    @DisplayName("Should successfully connect with all parameters including authentication")
+    void shouldConnectWithAllParams() {
+        Connection connectionConfig = new TestConnectionView(ConnectionEntity.Type.MILVUS, Map.of(
+                "uri", containerUri(),
+                "database", "default",
+                "username", MilvusTestResourceAuthenticated.USERNAME,
+                "password", MilvusTestResourceAuthenticated.PASSWORD));
+
+        ConnectionValidationResult result = connectionValidator.validate(connectionConfig);
+
+        assertTrue(result.valid(), "Connection validation with all parameters should succeed");
+        assertThat(result.message()).doesNotContainIgnoringCase("error", "fail", "invalid", "authentication");
     }
 }

--- a/debezium-platform-conductor/src/test/java/io/debezium/platform/environment/connection/MilvusConnectionValidatorIT.java
+++ b/debezium-platform-conductor/src/test/java/io/debezium/platform/environment/connection/MilvusConnectionValidatorIT.java
@@ -9,13 +9,18 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.net.InetSocketAddress;
+import java.net.Socket;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import jakarta.inject.Inject;
 
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.testcontainers.DockerClientFactory;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.shaded.org.awaitility.Awaitility;
 
@@ -39,19 +44,39 @@ import io.quarkus.test.junit.QuarkusTest;
 @QuarkusTestResource(MilvusTestResource.class)
 class MilvusConnectionValidatorIT {
 
+    @BeforeAll
+    static void checkDockerAvailable() {
+        Assumptions.assumeTrue(
+            DockerClientFactory.instance().isDockerAvailable(),
+            "Docker is not available; skipping Milvus integration tests"
+        );
+    }
+
     @Inject
     MilvusConnectionValidator connectionValidator;
+
+    private static void awaitPortOpen(GenericContainer<?> container, int internalPort) {
+        String host = container.getHost();
+        int port = container.getMappedPort(internalPort);
+
+        Awaitility.await()
+                .atMost(600, TimeUnit.SECONDS)
+                .pollInterval(2, TimeUnit.SECONDS)
+                .untilAsserted(() -> {
+                    try (Socket s = new Socket()) {
+                        s.connect(new InetSocketAddress(host, port), 1000);
+                    }
+                });
+    }
 
     @Test
     @DisplayName("Should successfully connect to Milvus without authentication")
     void shouldConnectWithoutAuth() {
         GenericContainer<?> container = MilvusTestResource.getContainer();
 
-        Awaitility.await()
-                .atMost(300, TimeUnit.SECONDS)
-                .until(container::isRunning);
+        awaitPortOpen(container, 19530);
 
-        String uri = String.format("http://%s:%d",
+        String uri = String.format("grpc://%s:%d",
                 container.getHost(),
                 container.getMappedPort(19530));
 
@@ -69,11 +94,9 @@ class MilvusConnectionValidatorIT {
     void shouldConnectWithDatabase() {
         GenericContainer<?> container = MilvusTestResource.getContainer();
 
-        Awaitility.await()
-                .atMost(300, TimeUnit.SECONDS)
-                .until(container::isRunning);
+        awaitPortOpen(container, 19530);
 
-        String uri = String.format("http://%s:%d",
+        String uri = String.format("grpc://%s:%d",
                 container.getHost(),
                 container.getMappedPort(19530));
 
@@ -91,7 +114,7 @@ class MilvusConnectionValidatorIT {
     @DisplayName("Should fail with invalid host")
     void shouldFailWithInvalidHost() {
         Connection connectionConfig = new TestConnectionView(ConnectionEntity.Type.MILVUS, Map.of(
-                "uri", "http://invalid-host-12345:19530"));
+                "uri", "grpc://invalid-host-12345:19530"));
 
         ConnectionValidationResult result = connectionValidator.validate(connectionConfig);
 
@@ -104,11 +127,9 @@ class MilvusConnectionValidatorIT {
     void shouldFailWithInvalidPort() {
         GenericContainer<?> container = MilvusTestResource.getContainer();
 
-        Awaitility.await()
-                .atMost(300, TimeUnit.SECONDS)
-                .until(container::isRunning);
+        awaitPortOpen(container, 19530);
 
-        String uri = String.format("http://%s:%d",
+        String uri = String.format("grpc://%s:%d",
                 container.getHost(),
                 99999); // Invalid port
 
@@ -126,7 +147,7 @@ class MilvusConnectionValidatorIT {
     void shouldHandleTimeout() {
         // Use a non-routable IP address to simulate timeout
         Connection connectionConfig = new TestConnectionView(ConnectionEntity.Type.MILVUS, Map.of(
-                "uri", "http://10.255.255.1:19530"));
+                "uri", "grpc://10.255.255.1:19530"));
 
         ConnectionValidationResult result = connectionValidator.validate(connectionConfig);
 
@@ -139,11 +160,9 @@ class MilvusConnectionValidatorIT {
     void shouldConnectWithUsernamePassword() {
         GenericContainer<?> container = MilvusTestResource.getContainer();
 
-        Awaitility.await()
-                .atMost(300, TimeUnit.SECONDS)
-                .until(container::isRunning);
+        awaitPortOpen(container, 19530);
 
-        String uri = String.format("http://%s:%d",
+        String uri = String.format("grpc://%s:%d",
                 container.getHost(),
                 container.getMappedPort(19530));
 
@@ -163,11 +182,9 @@ class MilvusConnectionValidatorIT {
     void shouldConnectWithTokenAuth() {
         GenericContainer<?> container = MilvusTestResource.getContainer();
 
-        Awaitility.await()
-                .atMost(300, TimeUnit.SECONDS)
-                .until(container::isRunning);
+        awaitPortOpen(container, 19530);
 
-        String uri = String.format("http://%s:%d",
+        String uri = String.format("grpc://%s:%d",
                 container.getHost(),
                 container.getMappedPort(19530));
 
@@ -186,11 +203,9 @@ class MilvusConnectionValidatorIT {
     void shouldFailWithInvalidCredentials() {
         GenericContainer<?> container = MilvusTestResource.getContainer();
 
-        Awaitility.await()
-                .atMost(300, TimeUnit.SECONDS)
-                .until(container::isRunning);
+        awaitPortOpen(container, 19530);
 
-        String uri = String.format("http://%s:%d",
+        String uri = String.format("grpc://%s:%d",
                 container.getHost(),
                 container.getMappedPort(19530));
 
@@ -210,11 +225,9 @@ class MilvusConnectionValidatorIT {
     void shouldFailWithInvalidToken() {
         GenericContainer<?> container = MilvusTestResource.getContainer();
 
-        Awaitility.await()
-                .atMost(300, TimeUnit.SECONDS)
-                .until(container::isRunning);
+        awaitPortOpen(container, 19530);
 
-        String uri = String.format("http://%s:%d",
+        String uri = String.format("grpc://%s:%d",
                 container.getHost(),
                 container.getMappedPort(19530));
 
@@ -233,11 +246,9 @@ class MilvusConnectionValidatorIT {
     void shouldConnectWithAllParams() {
         GenericContainer<?> container = MilvusTestResource.getContainer();
 
-        Awaitility.await()
-                .atMost(300, TimeUnit.SECONDS)
-                .until(container::isRunning);
+        awaitPortOpen(container, 19530);
 
-        String uri = String.format("http://%s:%d",
+        String uri = String.format("grpc://%s:%d",
                 container.getHost(),
                 container.getMappedPort(19530));
 

--- a/debezium-platform-conductor/src/test/java/io/debezium/platform/environment/connection/MilvusConnectionValidatorIT.java
+++ b/debezium-platform-conductor/src/test/java/io/debezium/platform/environment/connection/MilvusConnectionValidatorIT.java
@@ -23,6 +23,7 @@ import io.debezium.platform.data.dto.ConnectionValidationResult;
 import io.debezium.platform.data.model.ConnectionEntity;
 import io.debezium.platform.domain.views.Connection;
 import io.debezium.platform.environment.connection.destination.MilvusConnectionValidator;
+import io.debezium.platform.environment.database.db.MilvusTestResource;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 

--- a/debezium-platform-conductor/src/test/java/io/debezium/platform/environment/connection/MilvusConnectionValidatorIT.java
+++ b/debezium-platform-conductor/src/test/java/io/debezium/platform/environment/connection/MilvusConnectionValidatorIT.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.platform.environment.connection;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.shaded.org.awaitility.Awaitility;
+
+import io.debezium.platform.data.dto.ConnectionValidationResult;
+import io.debezium.platform.data.model.ConnectionEntity;
+import io.debezium.platform.domain.views.Connection;
+import io.debezium.platform.environment.connection.destination.MilvusConnectionValidator;
+import io.debezium.platform.environment.database.MilvusTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+
+/**
+ * Integration tests for {@link MilvusConnectionValidator} without authentication.
+ * <p>
+ * These tests use a real Milvus container (via Testcontainers) to verify
+ * connection validation against an actual Milvus instance without authentication.
+ * </p>
+ *
+ * @author Pranav Tiwari
+ */
+@QuarkusTest
+@QuarkusTestResource(MilvusTestResource.class)
+class MilvusConnectionValidatorIT {
+
+    @Inject
+    MilvusConnectionValidator connectionValidator;
+
+    @Test
+    @DisplayName("Should successfully connect to Milvus without authentication")
+    void shouldConnectWithoutAuth() {
+        GenericContainer<?> container = MilvusTestResource.getContainer();
+
+        Awaitility.await()
+                .atMost(300, TimeUnit.SECONDS)
+                .until(container::isRunning);
+
+        String uri = String.format("http://%s:%d",
+                container.getHost(),
+                container.getMappedPort(19530));
+
+        Connection connectionConfig = new TestConnectionView(ConnectionEntity.Type.MILVUS, Map.of(
+                "uri", uri));
+
+        ConnectionValidationResult result = connectionValidator.validate(connectionConfig);
+
+        assertTrue(result.valid(), "Connection validation should succeed");
+    }
+
+    @Test
+    @DisplayName("Should successfully connect with database parameter")
+    void shouldConnectWithDatabase() {
+        GenericContainer<?> container = MilvusTestResource.getContainer();
+
+        Awaitility.await()
+                .atMost(300, TimeUnit.SECONDS)
+                .until(container::isRunning);
+
+        String uri = String.format("http://%s:%d",
+                container.getHost(),
+                container.getMappedPort(19530));
+
+        Connection connectionConfig = new TestConnectionView(ConnectionEntity.Type.MILVUS, Map.of(
+                "uri", uri,
+                "database", "default"));
+
+        ConnectionValidationResult result = connectionValidator.validate(connectionConfig);
+
+        assertTrue(result.valid(), "Connection validation with database should succeed");
+    }
+
+    @Test
+    @DisplayName("Should fail with invalid host")
+    void shouldFailWithInvalidHost() {
+        Connection connectionConfig = new TestConnectionView(ConnectionEntity.Type.MILVUS, Map.of(
+                "uri", "http://invalid-host-12345:19530"));
+
+        ConnectionValidationResult result = connectionValidator.validate(connectionConfig);
+
+        assertFalse(result.valid(), "Connection validation should fail");
+        assertThat(result.message()).containsAnyOf("connect", "UNAVAILABLE", "unreachable", "timeout");
+    }
+
+    @Test
+    @DisplayName("Should fail with invalid port")
+    void shouldFailWithInvalidPort() {
+        GenericContainer<?> container = MilvusTestResource.getContainer();
+
+        Awaitility.await()
+                .atMost(300, TimeUnit.SECONDS)
+                .until(container::isRunning);
+
+        String uri = String.format("http://%s:%d",
+                container.getHost(),
+                99999); // Invalid port
+
+        Connection connectionConfig = new TestConnectionView(ConnectionEntity.Type.MILVUS, Map.of(
+                "uri", uri));
+
+        ConnectionValidationResult result = connectionValidator.validate(connectionConfig);
+
+        assertFalse(result.valid(), "Connection validation should fail");
+        assertThat(result.message()).containsAnyOf("connect", "refused", "UNAVAILABLE");
+    }
+
+    @Test
+    @DisplayName("Should handle timeout gracefully")
+    void shouldHandleTimeout() {
+        // Use a non-routable IP address to simulate timeout
+        Connection connectionConfig = new TestConnectionView(ConnectionEntity.Type.MILVUS, Map.of(
+                "uri", "http://10.255.255.1:19530"));
+
+        ConnectionValidationResult result = connectionValidator.validate(connectionConfig);
+
+        assertFalse(result.valid(), "Connection validation should fail");
+        assertThat(result.message()).containsAnyOf("timeout", "connect", "Connection timeout");
+    }
+}

--- a/debezium-platform-conductor/src/test/java/io/debezium/platform/environment/connection/MilvusConnectionValidatorIT.java
+++ b/debezium-platform-conductor/src/test/java/io/debezium/platform/environment/connection/MilvusConnectionValidatorIT.java
@@ -23,7 +23,6 @@ import io.debezium.platform.data.dto.ConnectionValidationResult;
 import io.debezium.platform.data.model.ConnectionEntity;
 import io.debezium.platform.domain.views.Connection;
 import io.debezium.platform.environment.connection.destination.MilvusConnectionValidator;
-import io.debezium.platform.environment.database.MilvusTestResource;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 
@@ -34,7 +33,6 @@ import io.quarkus.test.junit.QuarkusTest;
  * connection validation against an actual Milvus instance without authentication.
  * </p>
  *
- * @author Pranav Tiwari
  */
 @QuarkusTest
 @QuarkusTestResource(MilvusTestResource.class)
@@ -62,6 +60,7 @@ class MilvusConnectionValidatorIT {
         ConnectionValidationResult result = connectionValidator.validate(connectionConfig);
 
         assertTrue(result.valid(), "Connection validation should succeed");
+        assertThat(result.message()).doesNotContainIgnoringCase("error", "fail", "invalid");
     }
 
     @Test
@@ -84,6 +83,7 @@ class MilvusConnectionValidatorIT {
         ConnectionValidationResult result = connectionValidator.validate(connectionConfig);
 
         assertTrue(result.valid(), "Connection validation with database should succeed");
+        assertThat(result.message()).doesNotContainIgnoringCase("error", "fail", "invalid");
     }
 
     @Test
@@ -131,5 +131,124 @@ class MilvusConnectionValidatorIT {
 
         assertFalse(result.valid(), "Connection validation should fail");
         assertThat(result.message()).containsAnyOf("timeout", "connect", "Connection timeout");
+    }
+
+    @Test
+    @DisplayName("Should successfully connect with username and password authentication")
+    void shouldConnectWithUsernamePassword() {
+        GenericContainer<?> container = MilvusTestResource.getContainer();
+
+        Awaitility.await()
+                .atMost(300, TimeUnit.SECONDS)
+                .until(container::isRunning);
+
+        String uri = String.format("http://%s:%d",
+                container.getHost(),
+                container.getMappedPort(19530));
+
+        Connection connectionConfig = new TestConnectionView(ConnectionEntity.Type.MILVUS, Map.of(
+                "uri", uri,
+                "username", "root",
+                "password", "milvus"));
+
+        ConnectionValidationResult result = connectionValidator.validate(connectionConfig);
+
+        assertTrue(result.valid(), "Connection validation with username and password should succeed");
+        assertThat(result.message()).doesNotContainIgnoringCase("error", "fail", "invalid", "authentication");
+    }
+
+    @Test
+    @DisplayName("Should successfully connect with token authentication")
+    void shouldConnectWithTokenAuth() {
+        GenericContainer<?> container = MilvusTestResource.getContainer();
+
+        Awaitility.await()
+                .atMost(300, TimeUnit.SECONDS)
+                .until(container::isRunning);
+
+        String uri = String.format("http://%s:%d",
+                container.getHost(),
+                container.getMappedPort(19530));
+
+        Connection connectionConfig = new TestConnectionView(ConnectionEntity.Type.MILVUS, Map.of(
+                "uri", uri,
+                "token", "root:milvus"));
+
+        ConnectionValidationResult result = connectionValidator.validate(connectionConfig);
+
+        assertTrue(result.valid(), "Connection validation with token authentication should succeed");
+        assertThat(result.message()).doesNotContainIgnoringCase("error", "fail", "invalid", "authentication");
+    }
+
+    @Test
+    @DisplayName("Should fail with invalid username and password")
+    void shouldFailWithInvalidCredentials() {
+        GenericContainer<?> container = MilvusTestResource.getContainer();
+
+        Awaitility.await()
+                .atMost(300, TimeUnit.SECONDS)
+                .until(container::isRunning);
+
+        String uri = String.format("http://%s:%d",
+                container.getHost(),
+                container.getMappedPort(19530));
+
+        Connection connectionConfig = new TestConnectionView(ConnectionEntity.Type.MILVUS, Map.of(
+                "uri", uri,
+                "username", "root",
+                "password", "wrongpassword"));
+
+        ConnectionValidationResult result = connectionValidator.validate(connectionConfig);
+
+        assertFalse(result.valid(), "Connection validation with invalid credentials should fail");
+        assertThat(result.message()).containsAnyOf("authentication", "auth", "permission", "credentials");
+    }
+
+    @Test
+    @DisplayName("Should fail with invalid token")
+    void shouldFailWithInvalidToken() {
+        GenericContainer<?> container = MilvusTestResource.getContainer();
+
+        Awaitility.await()
+                .atMost(300, TimeUnit.SECONDS)
+                .until(container::isRunning);
+
+        String uri = String.format("http://%s:%d",
+                container.getHost(),
+                container.getMappedPort(19530));
+
+        Connection connectionConfig = new TestConnectionView(ConnectionEntity.Type.MILVUS, Map.of(
+                "uri", uri,
+                "token", "root:invalidtoken"));
+
+        ConnectionValidationResult result = connectionValidator.validate(connectionConfig);
+
+        assertFalse(result.valid(), "Connection validation with invalid token should fail");
+        assertThat(result.message()).containsAnyOf("authentication", "auth", "permission", "credentials");
+    }
+
+    @Test
+    @DisplayName("Should successfully connect with all parameters including authentication")
+    void shouldConnectWithAllParams() {
+        GenericContainer<?> container = MilvusTestResource.getContainer();
+
+        Awaitility.await()
+                .atMost(300, TimeUnit.SECONDS)
+                .until(container::isRunning);
+
+        String uri = String.format("http://%s:%d",
+                container.getHost(),
+                container.getMappedPort(19530));
+
+        Connection connectionConfig = new TestConnectionView(ConnectionEntity.Type.MILVUS, Map.of(
+                "uri", uri,
+                "database", "default",
+                "username", "root",
+                "password", "milvus"));
+
+        ConnectionValidationResult result = connectionValidator.validate(connectionConfig);
+
+        assertTrue(result.valid(), "Connection validation with all parameters should succeed");
+        assertThat(result.message()).doesNotContainIgnoringCase("error", "fail", "invalid", "authentication");
     }
 }

--- a/debezium-platform-conductor/src/test/java/io/debezium/platform/environment/connection/MilvusConnectionValidatorIT.java
+++ b/debezium-platform-conductor/src/test/java/io/debezium/platform/environment/connection/MilvusConnectionValidatorIT.java
@@ -60,10 +60,13 @@ class MilvusConnectionValidatorIT {
 
         Awaitility.await()
                 .atMost(600, TimeUnit.SECONDS)
+                .pollDelay(2, TimeUnit.SECONDS)
                 .pollInterval(2, TimeUnit.SECONDS)
-                .untilAsserted(() -> {
+                .ignoreExceptions()
+                .until(() -> {
                     try (Socket s = new Socket()) {
-                        s.connect(new InetSocketAddress(host, port), 1000);
+                        s.connect(new InetSocketAddress(host, port), 5000);
+                        return true;
                     }
                 });
     }

--- a/debezium-platform-conductor/src/test/java/io/debezium/platform/environment/connection/MilvusConnectionValidatorIT.java
+++ b/debezium-platform-conductor/src/test/java/io/debezium/platform/environment/connection/MilvusConnectionValidatorIT.java
@@ -16,13 +16,13 @@ import java.util.concurrent.TimeUnit;
 
 import jakarta.inject.Inject;
 
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.DockerClientFactory;
 import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.shaded.org.awaitility.Awaitility;
 
 import io.debezium.platform.data.dto.ConnectionValidationResult;
 import io.debezium.platform.data.model.ConnectionEntity;
@@ -47,9 +47,8 @@ class MilvusConnectionValidatorIT {
     @BeforeAll
     static void checkDockerAvailable() {
         Assumptions.assumeTrue(
-            DockerClientFactory.instance().isDockerAvailable(),
-            "Docker is not available; skipping Milvus integration tests"
-        );
+                DockerClientFactory.instance().isDockerAvailable(),
+                "Docker is not available; skipping Milvus integration tests");
     }
 
     @Inject

--- a/debezium-platform-conductor/src/test/java/io/debezium/platform/environment/connection/MilvusConnectionValidatorTest.java
+++ b/debezium-platform-conductor/src/test/java/io/debezium/platform/environment/connection/MilvusConnectionValidatorTest.java
@@ -28,7 +28,6 @@ import io.debezium.platform.environment.connection.destination.MilvusConnectionV
  * and edge cases in the validator implementation.
  * </p>
  *
- * @author Pranav Tiwari
  */
 class MilvusConnectionValidatorTest {
 
@@ -85,7 +84,7 @@ class MilvusConnectionValidatorTest {
     @Test
     @DisplayName("Should fail validation when URI doesn't start with http:// or https://")
     void shouldFailWhenUriHasInvalidProtocol() {
-        Connection connectionConfig = new TestConnectionView(ConnectionEntity.Type.MILVUS, 
+        Connection connectionConfig = new TestConnectionView(ConnectionEntity.Type.MILVUS,
                 Map.of("uri", "localhost:19530"));
 
         ConnectionValidationResult result = connectionValidator.validate(connectionConfig);

--- a/debezium-platform-conductor/src/test/java/io/debezium/platform/environment/connection/MilvusConnectionValidatorTest.java
+++ b/debezium-platform-conductor/src/test/java/io/debezium/platform/environment/connection/MilvusConnectionValidatorTest.java
@@ -90,7 +90,10 @@ class MilvusConnectionValidatorTest {
         ConnectionValidationResult result = connectionValidator.validate(connectionConfig);
 
         assertFalse(result.valid(), "Validation should fail for URI without http:// or https://");
-        Assertions.assertThat(result.message()).contains("URI must start with http:// or https://");
+        Assertions.assertThat(result.message())
+                .contains("URI must start with")
+                .contains("http://")
+                .contains("https://");
     }
 
     @Test

--- a/debezium-platform-conductor/src/test/java/io/debezium/platform/environment/connection/MilvusConnectionValidatorTest.java
+++ b/debezium-platform-conductor/src/test/java/io/debezium/platform/environment/connection/MilvusConnectionValidatorTest.java
@@ -1,0 +1,209 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.platform.environment.connection;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import io.debezium.platform.data.dto.ConnectionValidationResult;
+import io.debezium.platform.data.model.ConnectionEntity;
+import io.debezium.platform.domain.views.Connection;
+import io.debezium.platform.environment.connection.destination.MilvusConnectionValidator;
+
+/**
+ * Unit tests for {@link MilvusConnectionValidator}.
+ * <p>
+ * These tests validate the configuration validation logic without requiring
+ * an actual Milvus server. They test parameter validation, URI format checking,
+ * and edge cases in the validator implementation.
+ * </p>
+ *
+ * @author Pranav Tiwari
+ */
+class MilvusConnectionValidatorTest {
+
+    private MilvusConnectionValidator connectionValidator;
+
+    @BeforeEach
+    void setup() {
+        // Initialize with a default timeout of 5 seconds
+        connectionValidator = new MilvusConnectionValidator(5);
+    }
+
+    @Test
+    @DisplayName("Should fail validation when connection config is null")
+    void shouldFailWhenConfigIsNull() {
+        ConnectionValidationResult result = connectionValidator.validate(null);
+
+        assertFalse(result.valid(), "Validation should fail for null configuration");
+        Assertions.assertThat(result.message()).contains("cannot be null");
+    }
+
+    @Test
+    @DisplayName("Should fail validation when URI is missing")
+    void shouldFailWhenUriIsMissing() {
+        Connection connectionConfig = new TestConnectionView(ConnectionEntity.Type.MILVUS, Map.of());
+
+        ConnectionValidationResult result = connectionValidator.validate(connectionConfig);
+
+        assertFalse(result.valid(), "Validation should fail when URI is missing");
+        Assertions.assertThat(result.message()).contains("URI must be specified");
+    }
+
+    @Test
+    @DisplayName("Should fail validation when URI is empty")
+    void shouldFailWhenUriIsEmpty() {
+        Connection connectionConfig = new TestConnectionView(ConnectionEntity.Type.MILVUS, Map.of("uri", ""));
+
+        ConnectionValidationResult result = connectionValidator.validate(connectionConfig);
+
+        assertFalse(result.valid(), "Validation should fail when URI is empty");
+        Assertions.assertThat(result.message()).contains("URI must be specified");
+    }
+
+    @Test
+    @DisplayName("Should fail validation when URI is only whitespace")
+    void shouldFailWhenUriIsWhitespace() {
+        Connection connectionConfig = new TestConnectionView(ConnectionEntity.Type.MILVUS, Map.of("uri", "   "));
+
+        ConnectionValidationResult result = connectionValidator.validate(connectionConfig);
+
+        assertFalse(result.valid(), "Validation should fail when URI is only whitespace");
+        Assertions.assertThat(result.message()).contains("URI must be specified");
+    }
+
+    @Test
+    @DisplayName("Should fail validation when URI doesn't start with http:// or https://")
+    void shouldFailWhenUriHasInvalidProtocol() {
+        Connection connectionConfig = new TestConnectionView(ConnectionEntity.Type.MILVUS, 
+                Map.of("uri", "localhost:19530"));
+
+        ConnectionValidationResult result = connectionValidator.validate(connectionConfig);
+
+        assertFalse(result.valid(), "Validation should fail for URI without http:// or https://");
+        Assertions.assertThat(result.message()).contains("URI must start with http:// or https://");
+    }
+
+    @Test
+    @DisplayName("Should accept valid HTTP URI")
+    void shouldAcceptValidHttpUri() {
+        Map<String, Object> config = new HashMap<>();
+        config.put("uri", "http://localhost:19530");
+
+        Connection connectionConfig = new TestConnectionView(ConnectionEntity.Type.MILVUS, config);
+
+        // This will fail at connection time, but should pass URI validation
+        ConnectionValidationResult result = connectionValidator.validate(connectionConfig);
+
+        // Since we can't connect to a real server, it will fail, but not with URI validation error
+        if (!result.valid()) {
+            Assertions.assertThat(result.message()).doesNotContain("URI must start with");
+        }
+    }
+
+    @Test
+    @DisplayName("Should accept valid HTTPS URI")
+    void shouldAcceptValidHttpsUri() {
+        Map<String, Object> config = new HashMap<>();
+        config.put("uri", "https://milvus.example.com:19530");
+
+        Connection connectionConfig = new TestConnectionView(ConnectionEntity.Type.MILVUS, config);
+
+        // This will fail at connection time, but should pass URI validation
+        ConnectionValidationResult result = connectionValidator.validate(connectionConfig);
+
+        // Since we can't connect to a real server, it will fail, but not with URI validation error
+        if (!result.valid()) {
+            Assertions.assertThat(result.message()).doesNotContain("URI must start with");
+        }
+    }
+
+    @Test
+    @DisplayName("Should handle optional database parameter")
+    void shouldHandleOptionalDatabase() {
+        Map<String, Object> config = new HashMap<>();
+        config.put("uri", "http://10.255.255.1:19530"); // Non-routable IP, will timeout
+        config.put("database", "test_db");
+
+        Connection connectionConfig = new TestConnectionView(ConnectionEntity.Type.MILVUS, config);
+
+        ConnectionValidationResult result = connectionValidator.validate(connectionConfig);
+
+        // Will fail to connect, but should pass configuration validation
+        assertFalse(result.valid(), "Connection should fail to non-routable address");
+    }
+
+    @Test
+    @DisplayName("Should handle optional username and password")
+    void shouldHandleUsernamePassword() {
+        Map<String, Object> config = new HashMap<>();
+        config.put("uri", "http://10.255.255.1:19530"); // Non-routable IP
+        config.put("username", "testuser");
+        config.put("password", "testpass");
+
+        Connection connectionConfig = new TestConnectionView(ConnectionEntity.Type.MILVUS, config);
+
+        ConnectionValidationResult result = connectionValidator.validate(connectionConfig);
+
+        // Will fail to connect, but should pass configuration validation
+        assertFalse(result.valid(), "Connection should fail to non-routable address");
+    }
+
+    @Test
+    @DisplayName("Should handle optional token authentication")
+    void shouldHandleTokenAuth() {
+        Map<String, Object> config = new HashMap<>();
+        config.put("uri", "http://10.255.255.1:19530"); // Non-routable IP
+        config.put("token", "testuser:testpass");
+
+        Connection connectionConfig = new TestConnectionView(ConnectionEntity.Type.MILVUS, config);
+
+        ConnectionValidationResult result = connectionValidator.validate(connectionConfig);
+
+        // Will fail to connect, but should pass configuration validation
+        assertFalse(result.valid(), "Connection should fail to non-routable address");
+    }
+
+    @Test
+    @DisplayName("Should handle all optional parameters together")
+    void shouldHandleAllOptionalParameters() {
+        Map<String, Object> config = new HashMap<>();
+        config.put("uri", "http://10.255.255.1:19530"); // Non-routable IP
+        config.put("database", "test_db");
+        config.put("username", "testuser");
+        config.put("password", "testpass");
+
+        Connection connectionConfig = new TestConnectionView(ConnectionEntity.Type.MILVUS, config);
+
+        ConnectionValidationResult result = connectionValidator.validate(connectionConfig);
+
+        // Will fail to connect, but should pass configuration validation
+        assertFalse(result.valid(), "Connection should fail to non-routable address");
+    }
+
+    @Test
+    @DisplayName("Should trim whitespace from URI")
+    void shouldTrimUriWhitespace() {
+        Map<String, Object> config = new HashMap<>();
+        config.put("uri", "  http://10.255.255.1:19530  ");
+
+        Connection connectionConfig = new TestConnectionView(ConnectionEntity.Type.MILVUS, config);
+
+        ConnectionValidationResult result = connectionValidator.validate(connectionConfig);
+
+        // Should pass URI validation (trimming happens)
+        if (!result.valid()) {
+            Assertions.assertThat(result.message()).doesNotContain("URI must start with");
+        }
+    }
+}

--- a/debezium-platform-conductor/src/test/java/io/debezium/platform/environment/database/db/MilvusTestResource.java
+++ b/debezium-platform-conductor/src/test/java/io/debezium/platform/environment/database/db/MilvusTestResource.java
@@ -3,7 +3,7 @@
  *
  * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
-package io.debezium.platform.environment.database;
+package io.debezium.platform.environment.database.db;
 
 import java.util.Map;
 

--- a/debezium-platform-conductor/src/test/java/io/debezium/platform/environment/database/db/MilvusTestResource.java
+++ b/debezium-platform-conductor/src/test/java/io/debezium/platform/environment/database/db/MilvusTestResource.java
@@ -5,9 +5,11 @@
  */
 package io.debezium.platform.environment.database.db;
 
+import java.time.Duration;
 import java.util.Map;
 
 import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.utility.DockerImageName;
 
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
@@ -31,24 +33,28 @@ import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
  */
 public class MilvusTestResource implements QuarkusTestResourceLifecycleManager {
 
-    private static final String MILVUS_IMAGE = "milvusdb/milvus:latest";
-    private static final int MILVUS_PORT = 19530;
+    private static final String MILVUS_IMAGE = "milvusdb/milvus:v2.6.4";
+    private static final int MILVUS_GRPC_PORT = 19530;
+    private static final int MILVUS_HTTP_PORT = 9091;
+    private static final Duration MILVUS_STARTUP_TIMEOUT = Duration.ofMinutes(10);
 
     private static GenericContainer<?> milvusContainer;
 
     @Override
     public Map<String, String> start() {
         milvusContainer = new GenericContainer<>(DockerImageName.parse(MILVUS_IMAGE))
-                .withExposedPorts(MILVUS_PORT)
+                .withExposedPorts(MILVUS_GRPC_PORT, MILVUS_HTTP_PORT)
                 .withCommand("milvus", "run", "standalone")
                 .withEnv("ETCD_USE_EMBED", "true")
-                .withEnv("COMMON_STORAGETYPE", "local");
+                .withEnv("COMMON_STORAGETYPE", "local")
+                .waitingFor(Wait.forListeningPort().withStartupTimeout(MILVUS_STARTUP_TIMEOUT));
 
         milvusContainer.start();
 
         return Map.of(
                 "milvus.host", milvusContainer.getHost(),
-                "milvus.port", milvusContainer.getMappedPort(MILVUS_PORT).toString());
+                "milvus.grpc.port", milvusContainer.getMappedPort(MILVUS_GRPC_PORT).toString(),
+                "milvus.http.port", milvusContainer.getMappedPort(MILVUS_HTTP_PORT).toString());
     }
 
     @Override

--- a/debezium-platform-conductor/src/test/java/io/debezium/platform/environment/database/db/MilvusTestResource.java
+++ b/debezium-platform-conductor/src/test/java/io/debezium/platform/environment/database/db/MilvusTestResource.java
@@ -33,7 +33,7 @@ import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
  */
 public class MilvusTestResource implements QuarkusTestResourceLifecycleManager {
 
-    private static final String MILVUS_IMAGE = "milvusdb/milvus:v2.6.4";
+    private static final String MILVUS_IMAGE = "mirror.gcr.io/milvusdb/milvus:v2.6.4";
     private static final int MILVUS_GRPC_PORT = 19530;
     private static final int MILVUS_HTTP_PORT = 9091;
     private static final Duration MILVUS_STARTUP_TIMEOUT = Duration.ofMinutes(10);

--- a/debezium-platform-conductor/src/test/java/io/debezium/platform/environment/database/db/MilvusTestResourceAuthenticated.java
+++ b/debezium-platform-conductor/src/test/java/io/debezium/platform/environment/database/db/MilvusTestResourceAuthenticated.java
@@ -16,23 +16,27 @@ import org.testcontainers.utility.DockerImageName;
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
 
 /**
- * Test resource for Milvus vector database using Testcontainers.
+ * Test resource for Milvus vector database using Testcontainers WITH authentication.
  *
- * <p>This class provides a containerized Milvus instance WITHOUT authentication
+ * <p>This class provides a containerized Milvus instance WITH authorization enabled
  * for integration testing. It manages the lifecycle of a Docker container running
- * Milvus server in standalone mode, making it suitable for testing basic
- * connection validation scenarios.</p>
+ * Milvus server in standalone mode, making it suitable for testing authenticated
+ * connection validation scenarios (username/password and token based).</p>
  *
  * <p>The Milvus instance is configured with:
  * <ul>
  *   <li>Default port 19530 mapped to a random host port</li>
- *   <li>No authentication required</li>
+ *   <li>Authorization enabled ({@code common.security.authorizationEnabled=true})</li>
+ *   <li>Default root credentials ({@code root}/{@code Milvus})</li>
  *   <li>Standalone mode (single-node deployment)</li>
  * </ul>
  * </p>
  *
  */
-public class MilvusTestResource implements QuarkusTestResourceLifecycleManager {
+public class MilvusTestResourceAuthenticated implements QuarkusTestResourceLifecycleManager {
+
+    public static final String USERNAME = "root";
+    public static final String PASSWORD = "Milvus";
 
     private static final String MILVUS_IMAGE = "mirror.gcr.io/milvusdb/milvus:v2.6.4";
     private static final int MILVUS_GRPC_PORT = 19530;
@@ -51,6 +55,7 @@ public class MilvusTestResource implements QuarkusTestResourceLifecycleManager {
                 .withExposedPorts(MILVUS_GRPC_PORT, MILVUS_HTTP_PORT)
                 .withCommand("milvus", "run", "standalone")
                 .withEnv("DEPLOY_MODE", "STANDALONE")
+                .withEnv("COMMON_SECURITY_AUTHORIZATIONENABLED", "true")
                 .withEnv("ETCD_USE_EMBED", "true")
                 .withEnv("ETCD_DATA_DIR", "/var/lib/milvus/etcd")
                 .withEnv("ETCD_CONFIG_PATH", EMBED_ETCD_CONFIG_PATH)


### PR DESCRIPTION
### Description:

- Implement ConnectionValidator for Milvus
- Add MILVUS type to ConnectionEntity enum and JSON schema
- Support token and username/password authentication
- Include unit and integration tests with Testcontainers
- Configure connection timeout (60s default)


fixes https://github.com/debezium/dbz/issues/1097
[DBZ-9440](https://issues.redhat.com/browse/DBZ-9440)

