### PR TITLE
debezium/dbz#1076 Replace Blazebit Entity Views with dedicated DTOs in REST endpoints

### DIFF
--- a/debezium-platform-conductor/pom.xml
+++ b/debezium-platform-conductor/pom.xml
@@ -452,6 +452,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.mapstruct</groupId>
+            <artifactId>mapstruct</artifactId>
+            <version>${version.mapstruct}</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.infinispan</groupId>
             <artifactId>infinispan-client-hotrod</artifactId>
         </dependency>
@@ -614,6 +620,13 @@
                     <compilerArgs>
                         <arg>-parameters</arg>
                     </compilerArgs>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.mapstruct</groupId>
+                            <artifactId>mapstruct-processor</artifactId>
+                            <version>${version.mapstruct}</version>
+                        </path>
+                    </annotationProcessorPaths>
                 </configuration>
             </plugin>
             <plugin>

--- a/debezium-platform-conductor/src/main/java/io/debezium/platform/api/ConnectionResource.java
+++ b/debezium-platform-conductor/src/main/java/io/debezium/platform/api/ConnectionResource.java
@@ -34,13 +34,14 @@ import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 import org.jboss.logging.Logger;
 
-import com.blazebit.persistence.integration.jaxrs.EntityViewId;
-
+import io.debezium.platform.api.dto.ConnectionRequest;
+import io.debezium.platform.api.dto.ConnectionResponse;
+import io.debezium.platform.api.mapper.ConnectionMapper;
 import io.debezium.platform.data.dto.CollectionTree;
 import io.debezium.platform.data.dto.ConnectionValidationResult;
 import io.debezium.platform.domain.ConnectionSchemaService;
 import io.debezium.platform.domain.ConnectionService;
-import io.debezium.platform.domain.views.Connection;
+import io.debezium.platform.error.NotFoundException;
 
 @Tag(name = "connections")
 @OpenAPIDefinition(info = @Info(title = "Connection API", description = "CRUD operations over connection resource", version = "0.1.0", contact = @Contact(name = "Debezium", url = "https://github.com/debezium/debezium")))
@@ -50,49 +51,60 @@ public class ConnectionResource {
     Logger logger;
     ConnectionService connectionService;
     ConnectionSchemaService schemaService;
+    ConnectionMapper mapper;
 
-    public ConnectionResource(Logger logger, ConnectionService connectionService, ConnectionSchemaService schemaService) {
+    public ConnectionResource(
+                              Logger logger,
+                              ConnectionService connectionService,
+                              ConnectionSchemaService schemaService,
+                              ConnectionMapper mapper) {
         this.logger = logger;
         this.connectionService = connectionService;
         this.schemaService = schemaService;
+        this.mapper = mapper;
     }
 
     @Operation(summary = "Returns all available connections")
-    @APIResponse(responseCode = "200", content = @Content(mediaType = APPLICATION_JSON, schema = @Schema(implementation = Connection.class, required = true, type = SchemaType.ARRAY)))
+    @APIResponse(responseCode = "200", content = @Content(mediaType = APPLICATION_JSON, schema = @Schema(implementation = ConnectionResponse.class, required = true, type = SchemaType.ARRAY)))
     @GET
     public Response get() {
         var connections = connectionService.list();
-        return Response.ok(connections).build();
+        return Response.ok(mapper.toResponseList(connections)).build();
     }
 
     @Operation(summary = "Returns a connection with given id")
-    @APIResponse(responseCode = "200", content = @Content(mediaType = APPLICATION_JSON, schema = @Schema(implementation = Connection.class, required = true)))
+    @APIResponse(responseCode = "200", content = @Content(mediaType = APPLICATION_JSON, schema = @Schema(implementation = ConnectionResponse.class, required = true)))
     @GET
     @Path("/{id}")
     public Response getById(@PathParam("id") Long id) {
         return connectionService.findById(id)
-                .map(connection -> Response.ok(connection).build())
+                .map(mapper::toResponse)
+                .map(dto -> Response.ok(dto).build())
                 .orElseGet(() -> Response.status(Response.Status.NOT_FOUND).build());
     }
 
     @Operation(summary = "Creates new connection")
     @APIResponse(responseCode = "201", content = @Content(mediaType = APPLICATION_JSON, schema = @Schema(implementation = URI.class, required = true)))
     @POST
-    public Response post(@NotNull @Valid Connection connection, @Context UriInfo uriInfo) {
-        var created = connectionService.create(connection);
+    public Response post(@NotNull @Valid ConnectionRequest request, @Context UriInfo uriInfo) {
+        var view = connectionService.createEmpty();
+        mapper.applyToView(request, view);
+        var created = connectionService.create(view);
         URI uri = uriInfo.getAbsolutePathBuilder()
                 .path(Long.toString(created.getId()))
                 .build();
-        return Response.created(uri).entity(created).build();
+        return Response.created(uri).entity(mapper.toResponse(created)).build();
     }
 
     @Operation(summary = "Updates an existing connection")
-    @APIResponse(responseCode = "200", content = @Content(mediaType = APPLICATION_JSON, schema = @Schema(implementation = Connection.class, required = true)))
+    @APIResponse(responseCode = "200", content = @Content(mediaType = APPLICATION_JSON, schema = @Schema(implementation = ConnectionResponse.class, required = true)))
     @PUT
     @Path("/{id}")
-    public Response put(@EntityViewId("id") @NotNull @Valid Connection connection) {
-        var updated = connectionService.update(connection);
-        return Response.ok(updated).build();
+    public Response put(@PathParam("id") Long id, @NotNull @Valid ConnectionRequest request) {
+        var view = connectionService.findById(id).orElseThrow(() -> new NotFoundException(id));
+        mapper.applyToView(request, view);
+        var updated = connectionService.update(view);
+        return Response.ok(mapper.toResponse(updated)).build();
     }
 
     @Operation(summary = "Deletes an existing connection")
@@ -108,9 +120,11 @@ public class ConnectionResource {
     @APIResponse(responseCode = "200", content = @Content(mediaType = APPLICATION_JSON, schema = @Schema(implementation = ConnectionValidationResult.class, type = SchemaType.OBJECT)))
     @POST
     @Path("/validate")
-    public Response validateConnection(@NotNull @Valid Connection connection) {
+    public Response validateConnection(@NotNull @Valid ConnectionRequest request) {
+        var view = connectionService.createEmpty();
+        mapper.applyToView(request, view);
 
-        var connectionValidationResponse = connectionService.validateConnection(connection);
+        var connectionValidationResponse = connectionService.validateConnection(view);
 
         return Response.ok()
                 .type(MediaType.APPLICATION_JSON)

--- a/debezium-platform-conductor/src/main/java/io/debezium/platform/api/DestinationResource.java
+++ b/debezium-platform-conductor/src/main/java/io/debezium/platform/api/DestinationResource.java
@@ -32,10 +32,11 @@ import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 import org.jboss.logging.Logger;
 
-import com.blazebit.persistence.integration.jaxrs.EntityViewId;
-
+import io.debezium.platform.api.dto.DestinationRequest;
+import io.debezium.platform.api.dto.DestinationResponse;
+import io.debezium.platform.api.mapper.DestinationMapper;
 import io.debezium.platform.domain.DestinationService;
-import io.debezium.platform.domain.views.Destination;
+import io.debezium.platform.error.NotFoundException;
 
 @Tag(name = "destinations")
 @OpenAPIDefinition(info = @Info(title = "Destination API", description = "CRUD operations over Destination resource", version = "0.1.0", contact = @Contact(name = "Debezium", url = "https://github.com/debezium/debezium")))
@@ -44,48 +45,55 @@ public class DestinationResource {
 
     Logger logger;
     DestinationService destinationService;
+    DestinationMapper mapper;
 
-    public DestinationResource(Logger logger, DestinationService destinationService) {
+    public DestinationResource(Logger logger, DestinationService destinationService, DestinationMapper mapper) {
         this.logger = logger;
         this.destinationService = destinationService;
+        this.mapper = mapper;
     }
 
     @Operation(summary = "Returns all available destinations")
-    @APIResponse(responseCode = "200", content = @Content(mediaType = APPLICATION_JSON, schema = @Schema(implementation = Destination.class, required = true, type = SchemaType.ARRAY)))
+    @APIResponse(responseCode = "200", content = @Content(mediaType = APPLICATION_JSON, schema = @Schema(implementation = DestinationResponse.class, required = true, type = SchemaType.ARRAY)))
     @GET
     public Response get() {
         var destinations = destinationService.list();
-        return Response.ok(destinations).build();
+        return Response.ok(mapper.toResponseList(destinations)).build();
     }
 
     @Operation(summary = "Returns a destination with given id")
-    @APIResponse(responseCode = "200", content = @Content(mediaType = APPLICATION_JSON, schema = @Schema(implementation = Destination.class, required = true)))
+    @APIResponse(responseCode = "200", content = @Content(mediaType = APPLICATION_JSON, schema = @Schema(implementation = DestinationResponse.class, required = true)))
     @GET
     @Path("/{id}")
     public Response getById(@PathParam("id") Long id) {
         return destinationService.findById(id)
-                .map(destination -> Response.ok(destination).build())
+                .map(mapper::toResponse)
+                .map(dto -> Response.ok(dto).build())
                 .orElseGet(() -> Response.status(Response.Status.NOT_FOUND).build());
     }
 
     @Operation(summary = "Creates new destination")
     @APIResponse(responseCode = "201", content = @Content(mediaType = APPLICATION_JSON, schema = @Schema(implementation = URI.class, required = true)))
     @POST
-    public Response post(@NotNull @Valid Destination destination, @Context UriInfo uriInfo) {
-        var created = destinationService.create(destination);
+    public Response post(@NotNull @Valid DestinationRequest request, @Context UriInfo uriInfo) {
+        var view = destinationService.createEmpty();
+        mapper.applyToView(request, view);
+        var created = destinationService.create(view);
         URI uri = uriInfo.getAbsolutePathBuilder()
                 .path(Long.toString(created.getId()))
                 .build();
-        return Response.created(uri).entity(created).build();
+        return Response.created(uri).entity(mapper.toResponse(created)).build();
     }
 
     @Operation(summary = "Updates an existing destination")
-    @APIResponse(responseCode = "200", content = @Content(mediaType = APPLICATION_JSON, schema = @Schema(implementation = Destination.class, required = true)))
+    @APIResponse(responseCode = "200", content = @Content(mediaType = APPLICATION_JSON, schema = @Schema(implementation = DestinationResponse.class, required = true)))
     @PUT
     @Path("/{id}")
-    public Response put(@EntityViewId("id") @NotNull @Valid Destination destination) {
-        var updated = destinationService.update(destination);
-        return Response.ok(updated).build();
+    public Response put(@PathParam("id") Long id, @NotNull @Valid DestinationRequest request) {
+        var view = destinationService.findById(id).orElseThrow(() -> new NotFoundException(id));
+        mapper.applyToView(request, view);
+        var updated = destinationService.update(view);
+        return Response.ok(mapper.toResponse(updated)).build();
     }
 
     @Operation(summary = "Deletes an existing destination")

--- a/debezium-platform-conductor/src/main/java/io/debezium/platform/api/PipelineResource.java
+++ b/debezium-platform-conductor/src/main/java/io/debezium/platform/api/PipelineResource.java
@@ -34,15 +34,16 @@ import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 import org.jboss.logging.Logger;
 
-import com.blazebit.persistence.integration.jaxrs.EntityViewId;
-
+import io.debezium.platform.api.dto.PipelineRequest;
+import io.debezium.platform.api.dto.PipelineResponse;
+import io.debezium.platform.api.mapper.PipelineMapper;
 import io.debezium.platform.data.dto.SignalRequest;
 import io.debezium.platform.data.dto.SignalResponse;
 import io.debezium.platform.domain.PipelineService;
 import io.debezium.platform.domain.Signal;
-import io.debezium.platform.domain.views.Pipeline;
 import io.debezium.platform.environment.EnvironmentController;
 import io.debezium.platform.environment.logs.LogReader;
+import io.debezium.platform.error.NotFoundException;
 import io.smallrye.common.annotation.RunOnVirtualThread;
 
 @Tag(name = "pipelines")
@@ -52,48 +53,56 @@ public class PipelineResource {
 
     Logger logger;
     PipelineService pipelineService;
+    PipelineMapper mapper;
 
-    public PipelineResource(Logger logger, PipelineService pipelineService) {
+    public PipelineResource(Logger logger, PipelineService pipelineService, PipelineMapper mapper) {
         this.logger = logger;
         this.pipelineService = pipelineService;
+        this.mapper = mapper;
     }
 
     @Operation(summary = "Returns all available pipelines")
-    @APIResponse(responseCode = "200", content = @Content(mediaType = APPLICATION_JSON, schema = @Schema(implementation = Pipeline.class, required = true, type = SchemaType.ARRAY)))
+    @APIResponse(responseCode = "200", content = @Content(mediaType = APPLICATION_JSON, schema = @Schema(implementation = PipelineResponse.class, required = true, type = SchemaType.ARRAY)))
     @GET
     public Response get() {
         var pipelines = pipelineService.list();
-        return Response.ok(pipelines).build();
+        return Response.ok(mapper.toResponseList(pipelines)).build();
     }
 
     @Operation(summary = "Returns a pipeline with given id")
-    @APIResponse(responseCode = "200", content = @Content(mediaType = APPLICATION_JSON, schema = @Schema(implementation = Pipeline.class, required = true)))
+    @APIResponse(responseCode = "200", content = @Content(mediaType = APPLICATION_JSON, schema = @Schema(implementation = PipelineResponse.class, required = true)))
     @GET
     @Path("/{id}")
     public Response getById(@PathParam("id") Long id) {
         return pipelineService.findById(id)
-                .map(source -> Response.ok(source).build())
+                .map(mapper::toResponse)
+                .map(dto -> Response.ok(dto).build())
                 .orElseGet(() -> Response.status(Response.Status.NOT_FOUND).build());
     }
 
     @Operation(summary = "Creates new pipeline")
     @APIResponse(responseCode = "201", content = @Content(mediaType = APPLICATION_JSON, schema = @Schema(implementation = URI.class, required = true)))
     @POST
-    public Response post(@NotNull @Valid Pipeline pipeline, @Context UriInfo uriInfo) {
-        var created = pipelineService.create(pipeline);
+    public Response post(@NotNull @Valid PipelineRequest request, @Context UriInfo uriInfo) {
+        var view = pipelineService.createEmpty();
+        mapper.applyToView(request, view);
+        var created = pipelineService.create(view);
         URI uri = uriInfo.getAbsolutePathBuilder()
                 .path(Long.toString(created.getId()))
                 .build();
-        return Response.created(uri).entity(created).build();
+        return Response.created(uri).entity(mapper.toResponse(created)).build();
     }
 
     @Operation(summary = "Updates an existing pipeline")
-    @APIResponse(responseCode = "200", content = @Content(mediaType = APPLICATION_JSON, schema = @Schema(implementation = Pipeline.class, required = true)))
+    @APIResponse(responseCode = "200", content = @Content(mediaType = APPLICATION_JSON, schema = @Schema(implementation = PipelineResponse.class, required = true)))
     @PUT
     @Path("/{id}")
-    public Response put(@EntityViewId("id") @NotNull @Valid Pipeline pipeline) {
-        var updated = pipelineService.update(pipeline);
-        return Response.ok(updated).build();
+    public Response put(@PathParam("id") Long id, @NotNull @Valid PipelineRequest request) {
+        var view = pipelineService.findById(id)
+                .orElseThrow(() -> new NotFoundException(id));
+        mapper.applyToView(request, view);
+        var updated = pipelineService.update(view);
+        return Response.ok(mapper.toResponse(updated)).build();
     }
 
     @Operation(summary = "Deletes an existing pipeline")

--- a/debezium-platform-conductor/src/main/java/io/debezium/platform/api/SourceResource.java
+++ b/debezium-platform-conductor/src/main/java/io/debezium/platform/api/SourceResource.java
@@ -32,12 +32,13 @@ import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 import org.jboss.logging.Logger;
 
-import com.blazebit.persistence.integration.jaxrs.EntityViewId;
-
+import io.debezium.platform.api.dto.SourceRequest;
+import io.debezium.platform.api.dto.SourceResponse;
+import io.debezium.platform.api.mapper.SourceMapper;
 import io.debezium.platform.data.dto.SignalCollectionVerifyRequest;
 import io.debezium.platform.data.dto.SignalDataCollectionVerifyResponse;
 import io.debezium.platform.domain.SourceService;
-import io.debezium.platform.domain.views.Source;
+import io.debezium.platform.error.NotFoundException;
 
 @Tag(name = "sources")
 @OpenAPIDefinition(info = @Info(title = "Source API", description = "CRUD operations over Source resource", version = "0.1.0", contact = @Contact(name = "Debezium", url = "https://github.com/debezium/debezium")))
@@ -46,48 +47,55 @@ public class SourceResource {
 
     Logger logger;
     SourceService sourceService;
+    SourceMapper mapper;
 
-    public SourceResource(Logger logger, SourceService sourceService) {
+    public SourceResource(Logger logger, SourceService sourceService, SourceMapper mapper) {
         this.logger = logger;
         this.sourceService = sourceService;
+        this.mapper = mapper;
     }
 
     @Operation(summary = "Returns all available sources")
-    @APIResponse(responseCode = "200", content = @Content(mediaType = APPLICATION_JSON, schema = @Schema(implementation = Source.class, required = true, type = SchemaType.ARRAY)))
+    @APIResponse(responseCode = "200", content = @Content(mediaType = APPLICATION_JSON, schema = @Schema(implementation = SourceResponse.class, required = true, type = SchemaType.ARRAY)))
     @GET
     public Response get() {
         var sources = sourceService.list();
-        return Response.ok(sources).build();
+        return Response.ok(mapper.toResponseList(sources)).build();
     }
 
     @Operation(summary = "Returns a source with given id")
-    @APIResponse(responseCode = "200", content = @Content(mediaType = APPLICATION_JSON, schema = @Schema(implementation = Source.class, required = true)))
+    @APIResponse(responseCode = "200", content = @Content(mediaType = APPLICATION_JSON, schema = @Schema(implementation = SourceResponse.class, required = true)))
     @GET
     @Path("/{id}")
     public Response getById(@PathParam("id") Long id) {
         return sourceService.findById(id)
-                .map(source -> Response.ok(source).build())
+                .map(mapper::toResponse)
+                .map(dto -> Response.ok(dto).build())
                 .orElseGet(() -> Response.status(Response.Status.NOT_FOUND).build());
     }
 
     @Operation(summary = "Creates new source")
     @APIResponse(responseCode = "201", content = @Content(mediaType = APPLICATION_JSON, schema = @Schema(implementation = URI.class, required = true)))
     @POST
-    public Response post(@NotNull @Valid Source source, @Context UriInfo uriInfo) {
-        var created = sourceService.create(source);
+    public Response post(@NotNull @Valid SourceRequest request, @Context UriInfo uriInfo) {
+        var view = sourceService.createEmpty();
+        mapper.applyToView(request, view);
+        var created = sourceService.create(view);
         URI uri = uriInfo.getAbsolutePathBuilder()
                 .path(Long.toString(created.getId()))
                 .build();
-        return Response.created(uri).entity(created).build();
+        return Response.created(uri).entity(mapper.toResponse(created)).build();
     }
 
     @Operation(summary = "Updates an existing source")
-    @APIResponse(responseCode = "200", content = @Content(mediaType = APPLICATION_JSON, schema = @Schema(implementation = Source.class, required = true)))
+    @APIResponse(responseCode = "200", content = @Content(mediaType = APPLICATION_JSON, schema = @Schema(implementation = SourceResponse.class, required = true)))
     @PUT
     @Path("/{id}")
-    public Response put(@EntityViewId("id") @NotNull @Valid Source source) {
-        var updated = sourceService.update(source);
-        return Response.ok(updated).build();
+    public Response put(@PathParam("id") Long id, @NotNull @Valid SourceRequest request) {
+        var view = sourceService.findById(id).orElseThrow(() -> new NotFoundException(id));
+        mapper.applyToView(request, view);
+        var updated = sourceService.update(view);
+        return Response.ok(mapper.toResponse(updated)).build();
     }
 
     @Operation(summary = "Deletes an existing source")

--- a/debezium-platform-conductor/src/main/java/io/debezium/platform/api/TransformResource.java
+++ b/debezium-platform-conductor/src/main/java/io/debezium/platform/api/TransformResource.java
@@ -32,10 +32,11 @@ import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 import org.jboss.logging.Logger;
 
-import com.blazebit.persistence.integration.jaxrs.EntityViewId;
-
+import io.debezium.platform.api.dto.TransformRequest;
+import io.debezium.platform.api.dto.TransformResponse;
+import io.debezium.platform.api.mapper.TransformMapper;
 import io.debezium.platform.domain.TransformService;
-import io.debezium.platform.domain.views.Transform;
+import io.debezium.platform.error.NotFoundException;
 
 @Tag(name = "transforms")
 @OpenAPIDefinition(info = @Info(title = "Transform API", description = "CRUD operations over Source revault", version = "0.1.0", contact = @Contact(name = "Debezium", url = "https://github.com/debezium/debezium")))
@@ -44,48 +45,55 @@ public class TransformResource {
 
     Logger logger;
     TransformService transformService;
+    TransformMapper mapper;
 
-    public TransformResource(Logger logger, TransformService transformService) {
+    public TransformResource(Logger logger, TransformService transformService, TransformMapper mapper) {
         this.logger = logger;
         this.transformService = transformService;
+        this.mapper = mapper;
     }
 
     @Operation(summary = "Returns all available transformations")
-    @APIResponse(responseCode = "200", content = @Content(mediaType = APPLICATION_JSON, schema = @Schema(implementation = Transform.class, required = true, type = SchemaType.ARRAY)))
+    @APIResponse(responseCode = "200", content = @Content(mediaType = APPLICATION_JSON, schema = @Schema(implementation = TransformResponse.class, required = true, type = SchemaType.ARRAY)))
     @GET
     public Response get() {
-        var vaults = transformService.list();
-        return Response.ok(vaults).build();
+        var transforms = transformService.list();
+        return Response.ok(mapper.toResponseList(transforms)).build();
     }
 
     @Operation(summary = "Returns a transform with given id")
-    @APIResponse(responseCode = "200", content = @Content(mediaType = APPLICATION_JSON, schema = @Schema(implementation = Transform.class, required = true)))
+    @APIResponse(responseCode = "200", content = @Content(mediaType = APPLICATION_JSON, schema = @Schema(implementation = TransformResponse.class, required = true)))
     @GET
     @Path("/{id}")
     public Response getById(@PathParam("id") Long id) {
         return transformService.findById(id)
-                .map(transform -> Response.ok(transform).build())
+                .map(mapper::toResponse)
+                .map(dto -> Response.ok(dto).build())
                 .orElseGet(() -> Response.status(Response.Status.NOT_FOUND).build());
     }
 
     @Operation(summary = "Creates new transform")
     @APIResponse(responseCode = "201", content = @Content(mediaType = APPLICATION_JSON, schema = @Schema(implementation = URI.class, required = true)))
     @POST
-    public Response post(@NotNull @Valid Transform transform, @Context UriInfo uriInfo) {
-        var created = transformService.create(transform);
+    public Response post(@NotNull @Valid TransformRequest request, @Context UriInfo uriInfo) {
+        var view = transformService.createEmpty();
+        mapper.applyToView(request, view);
+        var created = transformService.create(view);
         URI uri = uriInfo.getAbsolutePathBuilder()
                 .path(Long.toString(created.getId()))
                 .build();
-        return Response.created(uri).entity(created).build();
+        return Response.created(uri).entity(mapper.toResponse(created)).build();
     }
 
     @Operation(summary = "Updates an existing transform")
-    @APIResponse(responseCode = "200", content = @Content(mediaType = APPLICATION_JSON, schema = @Schema(implementation = Transform.class, required = true)))
+    @APIResponse(responseCode = "200", content = @Content(mediaType = APPLICATION_JSON, schema = @Schema(implementation = TransformResponse.class, required = true)))
     @PUT
     @Path("/{id}")
-    public Response put(@EntityViewId("id") @NotNull @Valid Transform transform) {
-        var updated = transformService.update(transform);
-        return Response.ok(updated).build();
+    public Response put(@PathParam("id") Long id, @NotNull @Valid TransformRequest request) {
+        var view = transformService.findById(id).orElseThrow(() -> new NotFoundException(id));
+        mapper.applyToView(request, view);
+        var updated = transformService.update(view);
+        return Response.ok(mapper.toResponse(updated)).build();
     }
 
     @Operation(summary = "Deletes an existing transform")

--- a/debezium-platform-conductor/src/main/java/io/debezium/platform/api/VaultResource.java
+++ b/debezium-platform-conductor/src/main/java/io/debezium/platform/api/VaultResource.java
@@ -32,10 +32,11 @@ import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 import org.jboss.logging.Logger;
 
-import com.blazebit.persistence.integration.jaxrs.EntityViewId;
-
+import io.debezium.platform.api.dto.VaultRequest;
+import io.debezium.platform.api.dto.VaultResponse;
+import io.debezium.platform.api.mapper.VaultMapper;
 import io.debezium.platform.domain.VaultService;
-import io.debezium.platform.domain.views.Vault;
+import io.debezium.platform.error.NotFoundException;
 
 @Tag(name = "vaults")
 @OpenAPIDefinition(info = @Info(title = "Vault API", description = "CRUD operations over Source revault", version = "0.1.0", contact = @Contact(name = "Debezium", url = "https://github.com/debezium/debezium")))
@@ -44,48 +45,55 @@ public class VaultResource {
 
     Logger logger;
     VaultService vaultService;
+    VaultMapper mapper;
 
-    public VaultResource(Logger logger, VaultService vaultService) {
+    public VaultResource(Logger logger, VaultService vaultService, VaultMapper mapper) {
         this.logger = logger;
         this.vaultService = vaultService;
+        this.mapper = mapper;
     }
 
     @Operation(summary = "Returns all available vaults")
-    @APIResponse(responseCode = "200", content = @Content(mediaType = APPLICATION_JSON, schema = @Schema(implementation = Vault.class, required = true, type = SchemaType.ARRAY)))
+    @APIResponse(responseCode = "200", content = @Content(mediaType = APPLICATION_JSON, schema = @Schema(implementation = VaultResponse.class, required = true, type = SchemaType.ARRAY)))
     @GET
     public Response get() {
         var vaults = vaultService.list();
-        return Response.ok(vaults).build();
+        return Response.ok(mapper.toResponseList(vaults)).build();
     }
 
     @Operation(summary = "Returns a vault with given id")
-    @APIResponse(responseCode = "200", content = @Content(mediaType = APPLICATION_JSON, schema = @Schema(implementation = Vault.class, required = true)))
+    @APIResponse(responseCode = "200", content = @Content(mediaType = APPLICATION_JSON, schema = @Schema(implementation = VaultResponse.class, required = true)))
     @GET
     @Path("/{id}")
     public Response getById(@PathParam("id") Long id) {
         return vaultService.findById(id)
-                .map(vault -> Response.ok(vault).build())
+                .map(mapper::toResponse)
+                .map(dto -> Response.ok(dto).build())
                 .orElseGet(() -> Response.status(Response.Status.NOT_FOUND).build());
     }
 
     @Operation(summary = "Creates new vault")
     @APIResponse(responseCode = "201", content = @Content(mediaType = APPLICATION_JSON, schema = @Schema(implementation = URI.class, required = true)))
     @POST
-    public Response post(@NotNull @Valid Vault vault, @Context UriInfo uriInfo) {
-        var created = vaultService.create(vault);
+    public Response post(@NotNull @Valid VaultRequest request, @Context UriInfo uriInfo) {
+        var view = vaultService.createEmpty();
+        mapper.applyToView(request, view);
+        var created = vaultService.create(view);
         URI uri = uriInfo.getAbsolutePathBuilder()
                 .path(Long.toString(created.getId()))
                 .build();
-        return Response.created(uri).entity(created).build();
+        return Response.created(uri).entity(mapper.toResponse(created)).build();
     }
 
     @Operation(summary = "Updates an existing vault")
-    @APIResponse(responseCode = "200", content = @Content(mediaType = APPLICATION_JSON, schema = @Schema(implementation = Vault.class, required = true)))
+    @APIResponse(responseCode = "200", content = @Content(mediaType = APPLICATION_JSON, schema = @Schema(implementation = VaultResponse.class, required = true)))
     @PUT
     @Path("/{id}")
-    public Response put(@EntityViewId("id") @NotNull @Valid Vault vault) {
-        var updated = vaultService.update(vault);
-        return Response.ok(updated).build();
+    public Response put(@PathParam("id") Long id, @NotNull @Valid VaultRequest request) {
+        var view = vaultService.findById(id).orElseThrow(() -> new NotFoundException(id));
+        mapper.applyToView(request, view);
+        var updated = vaultService.update(view);
+        return Response.ok(mapper.toResponse(updated)).build();
     }
 
     @Operation(summary = "Deletes an existing vault")

--- a/debezium-platform-conductor/src/main/java/io/debezium/platform/api/dto/ConnectionRequest.java
+++ b/debezium-platform-conductor/src/main/java/io/debezium/platform/api/dto/ConnectionRequest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
 package io.debezium.platform.api.dto;
 
 import java.util.Map;

--- a/debezium-platform-conductor/src/main/java/io/debezium/platform/api/dto/ConnectionRequest.java
+++ b/debezium-platform-conductor/src/main/java/io/debezium/platform/api/dto/ConnectionRequest.java
@@ -1,0 +1,14 @@
+package io.debezium.platform.api.dto;
+
+import java.util.Map;
+
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+
+import io.debezium.platform.data.model.ConnectionEntity;
+
+public record ConnectionRequest(
+        @NotEmpty String name,
+        @NotNull ConnectionEntity.Type type,
+        Map<String, Object> config) {
+}

--- a/debezium-platform-conductor/src/main/java/io/debezium/platform/api/dto/ConnectionResponse.java
+++ b/debezium-platform-conductor/src/main/java/io/debezium/platform/api/dto/ConnectionResponse.java
@@ -1,0 +1,12 @@
+package io.debezium.platform.api.dto;
+
+import java.util.Map;
+
+import io.debezium.platform.data.model.ConnectionEntity;
+
+public record ConnectionResponse(
+        Long id,
+        String name,
+        ConnectionEntity.Type type,
+        Map<String, Object> config) {
+}

--- a/debezium-platform-conductor/src/main/java/io/debezium/platform/api/dto/ConnectionResponse.java
+++ b/debezium-platform-conductor/src/main/java/io/debezium/platform/api/dto/ConnectionResponse.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
 package io.debezium.platform.api.dto;
 
 import java.util.Map;

--- a/debezium-platform-conductor/src/main/java/io/debezium/platform/api/dto/DestinationRequest.java
+++ b/debezium-platform-conductor/src/main/java/io/debezium/platform/api/dto/DestinationRequest.java
@@ -1,0 +1,16 @@
+package io.debezium.platform.api.dto;
+
+import java.util.Map;
+import java.util.Set;
+
+import jakarta.validation.constraints.NotEmpty;
+
+public record DestinationRequest(
+        @NotEmpty String name,
+        String description,
+        @NotEmpty String type,
+        @NotEmpty String schema,
+        NamedRef connection,
+        Set<NamedRef> vaults,
+        Map<String, Object> config) {
+}

--- a/debezium-platform-conductor/src/main/java/io/debezium/platform/api/dto/DestinationRequest.java
+++ b/debezium-platform-conductor/src/main/java/io/debezium/platform/api/dto/DestinationRequest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
 package io.debezium.platform.api.dto;
 
 import java.util.Map;

--- a/debezium-platform-conductor/src/main/java/io/debezium/platform/api/dto/DestinationResponse.java
+++ b/debezium-platform-conductor/src/main/java/io/debezium/platform/api/dto/DestinationResponse.java
@@ -1,0 +1,15 @@
+package io.debezium.platform.api.dto;
+
+import java.util.Map;
+import java.util.Set;
+
+public record DestinationResponse(
+        Long id,
+        String name,
+        String description,
+        String type,
+        String schema,
+        NamedRef connection,
+        Set<NamedRef> vaults,
+        Map<String, Object> config) {
+}

--- a/debezium-platform-conductor/src/main/java/io/debezium/platform/api/dto/DestinationResponse.java
+++ b/debezium-platform-conductor/src/main/java/io/debezium/platform/api/dto/DestinationResponse.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
 package io.debezium.platform.api.dto;
 
 import java.util.Map;

--- a/debezium-platform-conductor/src/main/java/io/debezium/platform/api/dto/NamedRef.java
+++ b/debezium-platform-conductor/src/main/java/io/debezium/platform/api/dto/NamedRef.java
@@ -1,0 +1,6 @@
+package io.debezium.platform.api.dto;
+
+public record NamedRef(
+        Long id,
+        String name) {
+}

--- a/debezium-platform-conductor/src/main/java/io/debezium/platform/api/dto/NamedRef.java
+++ b/debezium-platform-conductor/src/main/java/io/debezium/platform/api/dto/NamedRef.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
 package io.debezium.platform.api.dto;
 
 public record NamedRef(

--- a/debezium-platform-conductor/src/main/java/io/debezium/platform/api/dto/PipelineRequest.java
+++ b/debezium-platform-conductor/src/main/java/io/debezium/platform/api/dto/PipelineRequest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
 package io.debezium.platform.api.dto;
 
 import java.util.List;

--- a/debezium-platform-conductor/src/main/java/io/debezium/platform/api/dto/PipelineRequest.java
+++ b/debezium-platform-conductor/src/main/java/io/debezium/platform/api/dto/PipelineRequest.java
@@ -1,0 +1,17 @@
+package io.debezium.platform.api.dto;
+
+import java.util.List;
+import java.util.Map;
+
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+
+public record PipelineRequest(
+        @NotEmpty String name,
+        String description,
+        @NotNull NamedRef source,
+        @NotNull NamedRef destination,
+        List<NamedRef> transforms,
+        @NotEmpty String logLevel,
+        Map<String, String> logLevels) {
+}

--- a/debezium-platform-conductor/src/main/java/io/debezium/platform/api/dto/PipelineResponse.java
+++ b/debezium-platform-conductor/src/main/java/io/debezium/platform/api/dto/PipelineResponse.java
@@ -1,0 +1,15 @@
+package io.debezium.platform.api.dto;
+
+import java.util.List;
+import java.util.Map;
+
+public record PipelineResponse(
+        Long id,
+        String name,
+        String description,
+        NamedRef source,
+        NamedRef destination,
+        List<NamedRef> transforms,
+        String logLevel,
+        Map<String, String> logLevels) {
+}

--- a/debezium-platform-conductor/src/main/java/io/debezium/platform/api/dto/PipelineResponse.java
+++ b/debezium-platform-conductor/src/main/java/io/debezium/platform/api/dto/PipelineResponse.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
 package io.debezium.platform.api.dto;
 
 import java.util.List;

--- a/debezium-platform-conductor/src/main/java/io/debezium/platform/api/dto/PredicateDto.java
+++ b/debezium-platform-conductor/src/main/java/io/debezium/platform/api/dto/PredicateDto.java
@@ -1,0 +1,9 @@
+package io.debezium.platform.api.dto;
+
+import java.util.Map;
+
+public record PredicateDto(
+        String type,
+        Map<String, Object> config,
+        boolean negate) {
+}

--- a/debezium-platform-conductor/src/main/java/io/debezium/platform/api/dto/PredicateDto.java
+++ b/debezium-platform-conductor/src/main/java/io/debezium/platform/api/dto/PredicateDto.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
 package io.debezium.platform.api.dto;
 
 import java.util.Map;

--- a/debezium-platform-conductor/src/main/java/io/debezium/platform/api/dto/SourceRequest.java
+++ b/debezium-platform-conductor/src/main/java/io/debezium/platform/api/dto/SourceRequest.java
@@ -1,0 +1,16 @@
+package io.debezium.platform.api.dto;
+
+import java.util.Map;
+import java.util.Set;
+
+import jakarta.validation.constraints.NotEmpty;
+
+public record SourceRequest(
+        @NotEmpty String name,
+        String description,
+        @NotEmpty String type,
+        @NotEmpty String schema,
+        NamedRef connection,
+        Set<NamedRef> vaults,
+        Map<String, Object> config) {
+}

--- a/debezium-platform-conductor/src/main/java/io/debezium/platform/api/dto/SourceRequest.java
+++ b/debezium-platform-conductor/src/main/java/io/debezium/platform/api/dto/SourceRequest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
 package io.debezium.platform.api.dto;
 
 import java.util.Map;

--- a/debezium-platform-conductor/src/main/java/io/debezium/platform/api/dto/SourceResponse.java
+++ b/debezium-platform-conductor/src/main/java/io/debezium/platform/api/dto/SourceResponse.java
@@ -1,0 +1,15 @@
+package io.debezium.platform.api.dto;
+
+import java.util.Map;
+import java.util.Set;
+
+public record SourceResponse(
+        Long id,
+        String name,
+        String description,
+        String type,
+        String schema,
+        NamedRef connection,
+        Set<NamedRef> vaults,
+        Map<String, Object> config) {
+}

--- a/debezium-platform-conductor/src/main/java/io/debezium/platform/api/dto/SourceResponse.java
+++ b/debezium-platform-conductor/src/main/java/io/debezium/platform/api/dto/SourceResponse.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
 package io.debezium.platform.api.dto;
 
 import java.util.Map;

--- a/debezium-platform-conductor/src/main/java/io/debezium/platform/api/dto/TransformRequest.java
+++ b/debezium-platform-conductor/src/main/java/io/debezium/platform/api/dto/TransformRequest.java
@@ -1,0 +1,16 @@
+package io.debezium.platform.api.dto;
+
+import java.util.Map;
+import java.util.Set;
+
+import jakarta.validation.constraints.NotEmpty;
+
+public record TransformRequest(
+        @NotEmpty String name,
+        String description,
+        @NotEmpty String type,
+        @NotEmpty String schema,
+        Set<NamedRef> vaults,
+        Map<String, Object> config,
+        PredicateDto predicate) {
+}

--- a/debezium-platform-conductor/src/main/java/io/debezium/platform/api/dto/TransformRequest.java
+++ b/debezium-platform-conductor/src/main/java/io/debezium/platform/api/dto/TransformRequest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
 package io.debezium.platform.api.dto;
 
 import java.util.Map;

--- a/debezium-platform-conductor/src/main/java/io/debezium/platform/api/dto/TransformResponse.java
+++ b/debezium-platform-conductor/src/main/java/io/debezium/platform/api/dto/TransformResponse.java
@@ -1,0 +1,15 @@
+package io.debezium.platform.api.dto;
+
+import java.util.Map;
+import java.util.Set;
+
+public record TransformResponse(
+        Long id,
+        String name,
+        String description,
+        String type,
+        String schema,
+        Set<NamedRef> vaults,
+        Map<String, Object> config,
+        PredicateDto predicate) {
+}

--- a/debezium-platform-conductor/src/main/java/io/debezium/platform/api/dto/TransformResponse.java
+++ b/debezium-platform-conductor/src/main/java/io/debezium/platform/api/dto/TransformResponse.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
 package io.debezium.platform.api.dto;
 
 import java.util.Map;

--- a/debezium-platform-conductor/src/main/java/io/debezium/platform/api/dto/VaultRequest.java
+++ b/debezium-platform-conductor/src/main/java/io/debezium/platform/api/dto/VaultRequest.java
@@ -1,0 +1,11 @@
+package io.debezium.platform.api.dto;
+
+import java.util.Map;
+
+import jakarta.validation.constraints.NotEmpty;
+
+public record VaultRequest(
+        @NotEmpty String name,
+        boolean plaintext,
+        Map<String, String> items) {
+}

--- a/debezium-platform-conductor/src/main/java/io/debezium/platform/api/dto/VaultRequest.java
+++ b/debezium-platform-conductor/src/main/java/io/debezium/platform/api/dto/VaultRequest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
 package io.debezium.platform.api.dto;
 
 import java.util.Map;

--- a/debezium-platform-conductor/src/main/java/io/debezium/platform/api/dto/VaultResponse.java
+++ b/debezium-platform-conductor/src/main/java/io/debezium/platform/api/dto/VaultResponse.java
@@ -1,0 +1,10 @@
+package io.debezium.platform.api.dto;
+
+import java.util.Map;
+
+public record VaultResponse(
+        Long id,
+        String name,
+        boolean plaintext,
+        Map<String, String> items) {
+}

--- a/debezium-platform-conductor/src/main/java/io/debezium/platform/api/dto/VaultResponse.java
+++ b/debezium-platform-conductor/src/main/java/io/debezium/platform/api/dto/VaultResponse.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
 package io.debezium.platform.api.dto;
 
 import java.util.Map;

--- a/debezium-platform-conductor/src/main/java/io/debezium/platform/api/mapper/BaseMapper.java
+++ b/debezium-platform-conductor/src/main/java/io/debezium/platform/api/mapper/BaseMapper.java
@@ -1,0 +1,32 @@
+package io.debezium.platform.api.mapper;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import jakarta.inject.Inject;
+
+import com.blazebit.persistence.view.EntityViewManager;
+
+import io.debezium.platform.api.dto.NamedRef;
+
+public abstract class BaseMapper {
+    @Inject
+    EntityViewManager evm;
+
+    protected <T> T toViewRef(Class<T> refType, NamedRef ref) {
+        return ref != null ? evm.getReference(refType, ref.id()) : null;
+    }
+
+    protected <T> Set<T> toViewRefSet(Class<T> refType, Set<NamedRef> refs) {
+        if (refs == null)
+            return null;
+        return refs.stream().map(r -> toViewRef(refType, r)).collect(Collectors.toSet());
+    }
+
+    protected <T> List<T> toViewRefList(Class<T> refType, List<NamedRef> refs) {
+        if (refs == null)
+            return null;
+        return refs.stream().map(r -> toViewRef(refType, r)).toList();
+    }
+}

--- a/debezium-platform-conductor/src/main/java/io/debezium/platform/api/mapper/BaseMapper.java
+++ b/debezium-platform-conductor/src/main/java/io/debezium/platform/api/mapper/BaseMapper.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
 package io.debezium.platform.api.mapper;
 
 import java.util.List;
@@ -19,14 +24,16 @@ public abstract class BaseMapper {
     }
 
     protected <T> Set<T> toViewRefSet(Class<T> refType, Set<NamedRef> refs) {
-        if (refs == null)
+        if (refs == null) {
             return null;
+        }
         return refs.stream().map(r -> toViewRef(refType, r)).collect(Collectors.toSet());
     }
 
     protected <T> List<T> toViewRefList(Class<T> refType, List<NamedRef> refs) {
-        if (refs == null)
+        if (refs == null) {
             return null;
+        }
         return refs.stream().map(r -> toViewRef(refType, r)).toList();
     }
 }

--- a/debezium-platform-conductor/src/main/java/io/debezium/platform/api/mapper/ConnectionMapper.java
+++ b/debezium-platform-conductor/src/main/java/io/debezium/platform/api/mapper/ConnectionMapper.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
 package io.debezium.platform.api.mapper;
 
 import java.util.List;

--- a/debezium-platform-conductor/src/main/java/io/debezium/platform/api/mapper/ConnectionMapper.java
+++ b/debezium-platform-conductor/src/main/java/io/debezium/platform/api/mapper/ConnectionMapper.java
@@ -1,0 +1,21 @@
+package io.debezium.platform.api.mapper;
+
+import java.util.List;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.MappingTarget;
+
+import io.debezium.platform.api.dto.ConnectionRequest;
+import io.debezium.platform.api.dto.ConnectionResponse;
+import io.debezium.platform.domain.views.Connection;
+
+@Mapper(componentModel = "cdi")
+public interface ConnectionMapper {
+    ConnectionResponse toResponse(Connection view);
+
+    List<ConnectionResponse> toResponseList(List<Connection> views);
+
+    @Mapping(target = "id", ignore = true)
+    void applyToView(ConnectionRequest request, @MappingTarget Connection connection);
+}

--- a/debezium-platform-conductor/src/main/java/io/debezium/platform/api/mapper/DestinationMapper.java
+++ b/debezium-platform-conductor/src/main/java/io/debezium/platform/api/mapper/DestinationMapper.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
 package io.debezium.platform.api.mapper;
 
 import java.util.List;

--- a/debezium-platform-conductor/src/main/java/io/debezium/platform/api/mapper/DestinationMapper.java
+++ b/debezium-platform-conductor/src/main/java/io/debezium/platform/api/mapper/DestinationMapper.java
@@ -1,0 +1,37 @@
+package io.debezium.platform.api.mapper;
+
+import java.util.List;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.MappingTarget;
+
+import io.debezium.platform.api.dto.DestinationRequest;
+import io.debezium.platform.api.dto.DestinationResponse;
+import io.debezium.platform.api.dto.NamedRef;
+import io.debezium.platform.domain.views.Destination;
+import io.debezium.platform.domain.views.refs.ConnectionReference;
+import io.debezium.platform.domain.views.refs.VaultReference;
+
+@Mapper(componentModel = "cdi")
+public abstract class DestinationMapper extends BaseMapper {
+
+    public abstract DestinationResponse toResponse(Destination view);
+
+    public abstract List<DestinationResponse> toResponseList(List<Destination> views);
+
+    public abstract NamedRef toRef(ConnectionReference ref);
+
+    public abstract NamedRef vaultToRef(VaultReference ref);
+
+    @Mapping(target = "id", ignore = true)
+    @Mapping(target = "connection", ignore = true)
+    @Mapping(target = "vaults", ignore = true)
+    abstract void applyBasicFields(DestinationRequest request, @MappingTarget Destination view);
+
+    public void applyToView(DestinationRequest request, Destination view) {
+        applyBasicFields(request, view);
+        view.setConnection(toViewRef(ConnectionReference.class, request.connection()));
+        view.setVaults(toViewRefSet(VaultReference.class, request.vaults()));
+    }
+}

--- a/debezium-platform-conductor/src/main/java/io/debezium/platform/api/mapper/PipelineMapper.java
+++ b/debezium-platform-conductor/src/main/java/io/debezium/platform/api/mapper/PipelineMapper.java
@@ -1,0 +1,49 @@
+package io.debezium.platform.api.mapper;
+
+import java.util.List;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.MappingTarget;
+
+import io.debezium.platform.api.dto.NamedRef;
+import io.debezium.platform.api.dto.PipelineRequest;
+import io.debezium.platform.api.dto.PipelineResponse;
+import io.debezium.platform.domain.views.Pipeline;
+import io.debezium.platform.domain.views.refs.DestinationReference;
+import io.debezium.platform.domain.views.refs.SourceReference;
+import io.debezium.platform.domain.views.refs.TransformReference;
+
+@Mapper(componentModel = "cdi")
+public abstract class PipelineMapper extends BaseMapper {
+
+    public abstract PipelineResponse toResponse(Pipeline view);
+
+    public abstract List<PipelineResponse> toResponseList(List<Pipeline> views);
+
+    public abstract NamedRef toSourceRef(SourceReference ref);
+
+    public abstract NamedRef toDestRef(DestinationReference ref);
+
+    public abstract NamedRef toTransformRef(TransformReference ref);
+
+    @Mapping(target = "id", ignore = true)
+    @Mapping(target = "source", ignore = true)
+    @Mapping(target = "destination", ignore = true)
+    @Mapping(target = "transforms", ignore = true)
+    @Mapping(target = "logLevels", ignore = true)
+    abstract void applyBasicFields(PipelineRequest request, @MappingTarget Pipeline view);
+
+    public void applyToView(PipelineRequest request, Pipeline view) {
+        applyBasicFields(request, view);
+        view.setSource(toViewRef(SourceReference.class, request.source()));
+        view.setDestination(toViewRef(DestinationReference.class, request.destination()));
+        view.setTransforms(toViewRefList(TransformReference.class, request.transforms()));
+        if (view.getLogLevels() != null) {
+            view.getLogLevels().clear();
+        }
+        if (request.logLevels() != null && view.getLogLevels() != null) {
+            view.getLogLevels().putAll(request.logLevels());
+        }
+    }
+}

--- a/debezium-platform-conductor/src/main/java/io/debezium/platform/api/mapper/PipelineMapper.java
+++ b/debezium-platform-conductor/src/main/java/io/debezium/platform/api/mapper/PipelineMapper.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
 package io.debezium.platform.api.mapper;
 
 import java.util.List;

--- a/debezium-platform-conductor/src/main/java/io/debezium/platform/api/mapper/SourceMapper.java
+++ b/debezium-platform-conductor/src/main/java/io/debezium/platform/api/mapper/SourceMapper.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
 package io.debezium.platform.api.mapper;
 
 import java.util.List;

--- a/debezium-platform-conductor/src/main/java/io/debezium/platform/api/mapper/SourceMapper.java
+++ b/debezium-platform-conductor/src/main/java/io/debezium/platform/api/mapper/SourceMapper.java
@@ -1,0 +1,37 @@
+package io.debezium.platform.api.mapper;
+
+import java.util.List;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.MappingTarget;
+
+import io.debezium.platform.api.dto.NamedRef;
+import io.debezium.platform.api.dto.SourceRequest;
+import io.debezium.platform.api.dto.SourceResponse;
+import io.debezium.platform.domain.views.Source;
+import io.debezium.platform.domain.views.refs.ConnectionReference;
+import io.debezium.platform.domain.views.refs.VaultReference;
+
+@Mapper(componentModel = "cdi")
+public abstract class SourceMapper extends BaseMapper {
+
+    public abstract SourceResponse toResponse(Source view);
+
+    public abstract List<SourceResponse> toResponseList(List<Source> views);
+
+    public abstract NamedRef toRef(ConnectionReference ref);
+
+    public abstract NamedRef vaultToRef(VaultReference ref);
+
+    @Mapping(target = "id", ignore = true)
+    @Mapping(target = "connection", ignore = true)
+    @Mapping(target = "vaults", ignore = true)
+    abstract void applyBasicFields(SourceRequest request, @MappingTarget Source view);
+
+    public void applyToView(SourceRequest request, Source view) {
+        applyBasicFields(request, view);
+        view.setConnection(toViewRef(ConnectionReference.class, request.connection()));
+        view.setVaults(toViewRefSet(VaultReference.class, request.vaults()));
+    }
+}

--- a/debezium-platform-conductor/src/main/java/io/debezium/platform/api/mapper/TransformMapper.java
+++ b/debezium-platform-conductor/src/main/java/io/debezium/platform/api/mapper/TransformMapper.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
 package io.debezium.platform.api.mapper;
 
 import java.util.List;

--- a/debezium-platform-conductor/src/main/java/io/debezium/platform/api/mapper/TransformMapper.java
+++ b/debezium-platform-conductor/src/main/java/io/debezium/platform/api/mapper/TransformMapper.java
@@ -1,0 +1,46 @@
+package io.debezium.platform.api.mapper;
+
+import java.util.List;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.MappingTarget;
+
+import io.debezium.platform.api.dto.NamedRef;
+import io.debezium.platform.api.dto.PredicateDto;
+import io.debezium.platform.api.dto.TransformRequest;
+import io.debezium.platform.api.dto.TransformResponse;
+import io.debezium.platform.domain.views.Predicate;
+import io.debezium.platform.domain.views.Transform;
+import io.debezium.platform.domain.views.refs.VaultReference;
+
+@Mapper(componentModel = "cdi")
+public abstract class TransformMapper extends BaseMapper {
+
+    public abstract TransformResponse toResponse(Transform view);
+
+    public abstract List<TransformResponse> toResponseList(List<Transform> views);
+
+    public abstract NamedRef vaultToRef(VaultReference ref);
+
+    public abstract PredicateDto predicateToDto(Predicate predicate);
+
+    @Mapping(target = "id", ignore = true)
+    @Mapping(target = "vaults", ignore = true)
+    @Mapping(target = "predicate", ignore = true)
+    abstract void applyBasicFields(TransformRequest request, @MappingTarget Transform view);
+
+    public void applyToView(TransformRequest request, Transform view) {
+        applyBasicFields(request, view);
+        if (request.vaults() != null) {
+            view.setVaults(toViewRefSet(VaultReference.class, request.vaults()));
+        }
+        if (request.predicate() != null) {
+            Predicate pred = view.getPredicate() != null ? view.getPredicate() : evm.create(Predicate.class);
+            pred.setType(request.predicate().type());
+            pred.setConfig(request.predicate().config());
+            pred.setNegate(request.predicate().negate());
+            view.setPredicate(pred);
+        }
+    }
+}

--- a/debezium-platform-conductor/src/main/java/io/debezium/platform/api/mapper/VaultMapper.java
+++ b/debezium-platform-conductor/src/main/java/io/debezium/platform/api/mapper/VaultMapper.java
@@ -1,0 +1,21 @@
+package io.debezium.platform.api.mapper;
+
+import java.util.List;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.MappingTarget;
+
+import io.debezium.platform.api.dto.VaultRequest;
+import io.debezium.platform.api.dto.VaultResponse;
+import io.debezium.platform.domain.views.Vault;
+
+@Mapper(componentModel = "cdi")
+public interface VaultMapper {
+    VaultResponse toResponse(Vault view);
+
+    List<VaultResponse> toResponseList(List<Vault> views);
+
+    @Mapping(target = "id", ignore = true)
+    void applyToView(VaultRequest request, @MappingTarget Vault view);
+}

--- a/debezium-platform-conductor/src/main/java/io/debezium/platform/api/mapper/VaultMapper.java
+++ b/debezium-platform-conductor/src/main/java/io/debezium/platform/api/mapper/VaultMapper.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
 package io.debezium.platform.api.mapper;
 
 import java.util.List;

--- a/debezium-platform-conductor/src/main/java/io/debezium/platform/domain/AbstractService.java
+++ b/debezium-platform-conductor/src/main/java/io/debezium/platform/domain/AbstractService.java
@@ -91,6 +91,10 @@ public class AbstractService<E, T extends IdView, R extends IdView> {
         return view;
     }
 
+    public T createEmpty() {
+        return evm.create(viewType);
+    }
+
     public T update(@Valid T view) {
         findByIdAs(viewType, view.getId()).orElseThrow(() -> new NotFoundException(view.getId()));
         evm.save(em, view);

--- a/debezium-platform-conductor/src/main/java/io/debezium/platform/error/GlobalExceptionMapper.java
+++ b/debezium-platform-conductor/src/main/java/io/debezium/platform/error/GlobalExceptionMapper.java
@@ -9,6 +9,7 @@ import java.util.List;
 
 import jakarta.validation.ConstraintViolationException;
 import jakarta.ws.rs.NotSupportedException;
+import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.Response;
 
 import org.jboss.resteasy.reactive.server.ServerExceptionMapper;
@@ -18,6 +19,17 @@ import org.slf4j.LoggerFactory;
 public class GlobalExceptionMapper {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(GlobalExceptionMapper.class);
+
+    @ServerExceptionMapper(WebApplicationException.class)
+    public Response mapWebApplicationException(WebApplicationException ex) {
+
+        LOGGER.error("Error while processing request", ex);
+
+        int status = ex.getResponse().getStatus();
+        return Response.status(status)
+                .entity(new ErrorResponse(ex.getMessage(), List.of()))
+                .build();
+    }
 
     @ServerExceptionMapper(RuntimeException.class)
     public Response mapRuntimeException(RuntimeException ex) {

--- a/debezium-platform-conductor/src/test/java/io/debezium/platform/api/ConnectionResourceIT.java
+++ b/debezium-platform-conductor/src/test/java/io/debezium/platform/api/ConnectionResourceIT.java
@@ -8,6 +8,7 @@ package io.debezium.platform.api;
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.Matchers.hasItem;
 
 import org.junit.jupiter.api.Test;
 
@@ -206,6 +207,26 @@ public class ConnectionResourceIT {
                 .post("api/connections")
                 .then()
                 .statusCode(400);
+    }
+
+    @Test
+    public void testCreateConnection_NullType() {
+        String json = """
+                {
+                  "name": "test-connection",
+                  "config": {}
+                }
+                """;
+
+        given()
+                .contentType(ContentType.JSON)
+                .body(json)
+                .when()
+                .post("api/connections")
+                .then()
+                .statusCode(400)
+                .body("title", is("Constraint Violation"))
+                .body("violations.field", hasItem("post.request.type"));
     }
 
     @Test

--- a/debezium-platform-conductor/src/test/java/io/debezium/platform/api/PipelineResourceIT.java
+++ b/debezium-platform-conductor/src/test/java/io/debezium/platform/api/PipelineResourceIT.java
@@ -7,11 +7,12 @@ package io.debezium.platform.api;
 
 import static io.restassured.RestAssured.given;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.hasItem;
-import static org.hamcrest.Matchers.is;
 
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
+import java.util.stream.Stream;
 
 import jakarta.inject.Inject;
 
@@ -19,6 +20,9 @@ import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.testcontainers.shaded.org.awaitility.Awaitility;
@@ -283,6 +287,60 @@ class PipelineResourceIT {
                 .body("status", is(400))
                 .body("violations.field", hasItem("name"))
                 .body("violations.message", hasItem("Pipeline name must be a lowercase RFC 1123 subdomain"));
+    }
+
+    @ParameterizedTest(name = "Creating a pipeline without required {0} should return 400")
+    @MethodSource("invalidPipelineRequests")
+    void rejectPipelineWithMissingRequiredField(String fieldName, String jsonBody) {
+
+        given()
+                .header("Content-Type", "application/json")
+                .body(jsonBody).when().post("api/pipelines")
+                .then()
+                .statusCode(400)
+                .body("title", is("Constraint Violation"))
+                .body("violations.field", hasItem("post.request." + fieldName));
+    }
+
+    static Stream<Arguments> invalidPipelineRequests() {
+        return Stream.of(
+                Arguments.of("name", """
+                        {
+                        "name": "",
+                        "source": {"id": 1},
+                        "destination": {"id": 1},
+                        "logLevel": "INFO"
+                        }"""),
+                Arguments.of("source", """
+                        {
+                        "name": "test-pipeline",
+                        "destination": {"id": 1},
+                        "logLevel": "INFO"
+                        }"""),
+                Arguments.of("destination", """
+                        {
+                        "name": "test-pipeline",
+                        "source": {"id": 1},
+                        "logLevel": "INFO"
+                        }"""),
+                Arguments.of("logLevel", """
+                        {
+                        "name": "test-pipeline",
+                        "source": {"id": 1},
+                        "destination": {"id": 1},
+                        "logLevel": ""
+                        }"""));
+    }
+
+    @Test
+    @DisplayName("Sending a null body to POST pipelines should return 400")
+    void createPipelineWithNullBody() {
+
+        given()
+                .header("Content-Type", "application/json")
+                .when().post("api/pipelines")
+                .then()
+                .statusCode(400);
     }
 
 }

--- a/debezium-platform-conductor/src/test/java/io/debezium/platform/api/SourceResourceIT.java
+++ b/debezium-platform-conductor/src/test/java/io/debezium/platform/api/SourceResourceIT.java
@@ -7,21 +7,28 @@ package io.debezium.platform.api;
 
 import static io.restassured.RestAssured.given;
 import static io.restassured.module.jsv.JsonSchemaValidator.matchesJsonSchemaInClasspath;
+import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
 
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.stream.Stream;
 
 import jakarta.inject.Inject;
 
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import io.agroal.api.AgroalDataSource;
 import io.debezium.platform.util.TestDatasourceHelper;
 import io.quarkus.arc.InjectableInstance;
 import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.http.ContentType;
 
 @QuarkusTest
 class SourceResourceIT {
@@ -92,6 +99,56 @@ class SourceResourceIT {
                 .statusCode(200)
                 .body("exists", equalTo(true))
                 .body("message", equalTo("Signal data collection correctly configured"));
+    }
+
+    @ParameterizedTest(name = "Creating a source with empty {0} should return 400")
+    @MethodSource("invalidSourceRequests")
+    void createSourceWithInvalidField(String fieldName, String jsonBody) {
+        given()
+                .contentType(ContentType.JSON)
+                .body(jsonBody)
+                .when()
+                .post("api/sources")
+                .then()
+                .statusCode(400)
+                .body("title", is("Constraint Violation"))
+                .body("violations.field", hasItem("post.request." + fieldName));
+    }
+
+    static Stream<Arguments> invalidSourceRequests() {
+        return Stream.of(
+                Arguments.of("name", """
+                        {
+                          "name": "",
+                          "type": "postgres",
+                          "schema": "dummy",
+                          "config": {}
+                        }"""),
+                Arguments.of("type", """
+                        {
+                          "name": "test-source",
+                          "type": "",
+                          "schema": "dummy",
+                          "config": {}
+                        }"""),
+                Arguments.of("schema", """
+                        {
+                          "name": "test-source",
+                          "type": "postgres",
+                          "schema": "",
+                          "config": {}
+                        }"""));
+    }
+
+    @Test
+    @DisplayName("Sending a null body to POST sources should return 400")
+    void createSourceWithNullBody() {
+        given()
+                .contentType(ContentType.JSON)
+                .when()
+                .post("api/sources")
+                .then()
+                .statusCode(400);
     }
 
     private void createDataSignalDataCollection() {


### PR DESCRIPTION
debezium/dbz#1076

Replaces Blazebit Entity Views with dedicated request/response Java records in REST endpoints, resolving Bean Validation incompatibility

Changes:
  - Added request/response records per resource in `api/dto`
  - Added MapStruct mappers in `api/mapper`                                                                                                                                                                      
  - Updated all resource classes (Source, Destination, Transform, Vault,
    Connection, Pipeline) to accept/return DTOs                                                                                                                                                                  
  - Added MapStruct dependency and annotation processor to `pom.xml`

Unchanged:
 - All services                                                                                                                                                                                                 
 - All Blazebit entity views (still used internally between resource and DB)
 - All JPA entities                                                                                                                                                                                             
 - JSON API contract — verified field-by-field against pre-refactor responses with curl

Identified pre-existing issue:
 `PUT /pipelines/{id}` with a non-empty `logLevels` map fails with                                                                                                                                              
  `NoClassDefFoundError: org.hibernate.sql.exec.spi.JdbcOperationQueryUpdate`.                                                                                                                                   
  Reproduced on `main` (pre-refactor) — caused by Blaze-Persistence 1.6.18                                                                                                                                       
  shipping `blaze-persistence-integration-hibernate-7.1` while Quarkus 3.34                                                                                                                                      
  pulls Hibernate ORM 7.2.6, which moved that class from .spi to .internal
  
 Fix verified locally: swapping the dependency to                                                                                                                                                               
  blaze-persistence-integration-hibernate-7.2 ( [Blaze 1.6.18](https://persistence.blazebit.com/news/2026/blaze-persistence-1.6.18-release.html), released                                                                                                                                       
  Feb 2026 — see Blazebit/blaze-persistence#2092) makes the failing PUT                                                                                                                                          
  return 200. Left out of this PR to keep it focused on the DTO refactor;                                                                                                                                        
  happy to submit as a follow-up.

Closes debezium/dbz#1076