### PR TITLE
Add `ingress.className` support in example YAML configuration

### DIFF
--- a/examples/example.yaml
+++ b/examples/example.yaml
@@ -2,3 +2,5 @@ domain:
   name: platform.debezium.io
 database:
   enabled: true
+ingress:
+  className: nginx


### PR DESCRIPTION
Fixes debezium/dbz#1835

## Description
Developer is missing the ingress className for local chart deployment with kind kubernetes cluster.

## PR Checklist
- [X] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [X] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [X] One feature/change per PR unless tightly coupled
- [X] Do a rebase on upstream `main`
