### PR TITLE
debezium/dbz#1836: Add SQL Server-specific db name config in Pipelinemapper

### DIFF
--- a/debezium-platform-conductor/src/main/java/io/debezium/platform/environment/database/DatabaseConnectionConfiguration.java
+++ b/debezium-platform-conductor/src/main/java/io/debezium/platform/environment/database/DatabaseConnectionConfiguration.java
@@ -26,6 +26,7 @@ public class DatabaseConnectionConfiguration {
 
     public static final String DEBEZIUM_DATABASE_USERNAME_CONFIG = "user";
     public static final String DEBEZIUM_DATABASE_NAME_CONFIG = "dbname";
+    public static final String DEBEZIUM_SQLSERVER_DATABASE_NAME_CONFIG = "dbnames";
     private final DatabaseType databaseType;
     private final String hostname;
     private final int port;

--- a/debezium-platform-conductor/src/main/java/io/debezium/platform/environment/database/DatabaseConnectionConfiguration.java
+++ b/debezium-platform-conductor/src/main/java/io/debezium/platform/environment/database/DatabaseConnectionConfiguration.java
@@ -26,7 +26,7 @@ public class DatabaseConnectionConfiguration {
 
     public static final String DEBEZIUM_DATABASE_USERNAME_CONFIG = "user";
     public static final String DEBEZIUM_DATABASE_NAME_CONFIG = "dbname";
-    public static final String DEBEZIUM_SQLSERVER_DATABASE_NAME_CONFIG = "dbnames";
+    public static final String DEBEZIUM_SQLSERVER_DATABASE_NAME_CONFIG = "names";
     private final DatabaseType databaseType;
     private final String hostname;
     private final int port;

--- a/debezium-platform-conductor/src/main/java/io/debezium/platform/environment/operator/PipelineMapper.java
+++ b/debezium-platform-conductor/src/main/java/io/debezium/platform/environment/operator/PipelineMapper.java
@@ -180,7 +180,8 @@ public class PipelineMapper {
         if (source.getConnection() != null) { // backward compatibility
             ConnectionEntity.Type connectionType = source.getConnection().getType();
             String configPrefix = prefixResolver(connectionType);
-            source.getConnection().getConfig().forEach((configName, configValue) -> sourceConfig.setProps(getName(connectionType, configName, configPrefix), configValue));
+            source.getConnection().getConfig()
+                    .forEach((configName, configValue) -> sourceConfig.setProps(getName(connectionType, configName, configPrefix), configValue));
         }
 
         sourceConfig.setAllProps(source.getConfig());

--- a/debezium-platform-conductor/src/main/java/io/debezium/platform/environment/operator/PipelineMapper.java
+++ b/debezium-platform-conductor/src/main/java/io/debezium/platform/environment/operator/PipelineMapper.java
@@ -7,6 +7,7 @@ package io.debezium.platform.environment.operator;
 
 import static io.debezium.platform.environment.database.DatabaseConnectionConfiguration.DATABASE;
 import static io.debezium.platform.environment.database.DatabaseConnectionConfiguration.DEBEZIUM_DATABASE_NAME_CONFIG;
+import static io.debezium.platform.environment.database.DatabaseConnectionConfiguration.DEBEZIUM_SQLSERVER_DATABASE_NAME_CONFIG;
 import static io.debezium.platform.environment.database.DatabaseConnectionConfiguration.DEBEZIUM_DATABASE_USERNAME_CONFIG;
 import static io.debezium.platform.environment.database.DatabaseConnectionConfiguration.USERNAME;
 import static io.debezium.platform.environment.database.DatabaseConnectionFactory.DATABASE_CONNECTION_CONFIGURATION_PREFIX;
@@ -177,8 +178,9 @@ public class PipelineMapper {
         var sourceConfig = new ConfigProperties();
 
         if (source.getConnection() != null) { // backward compatibility
-            String configPrefix = prefixResolver(source.getConnection().getType());
-            source.getConnection().getConfig().forEach((configName, configValue) -> sourceConfig.setProps(getName(configName, configPrefix), configValue));
+            ConnectionEntity.Type connectionType = source.getConnection().getType();
+            String configPrefix = prefixResolver(connectionType);
+            source.getConnection().getConfig().forEach((configName, configValue) -> sourceConfig.setProps(getName(connectionType, configName, configPrefix), configValue));
         }
 
         sourceConfig.setAllProps(source.getConfig());
@@ -193,12 +195,19 @@ public class PipelineMapper {
                 .build();
     }
 
-    private static String getName(String configName, String configPrefix) {
+    private static String getName(ConnectionEntity.Type connectionType, String configName, String configPrefix) {
         return switch (configName) {
             case USERNAME -> configPrefix + DEBEZIUM_DATABASE_USERNAME_CONFIG;
-            case DATABASE -> configPrefix + DEBEZIUM_DATABASE_NAME_CONFIG;
+            case DATABASE -> configPrefix + databaseNameConfig(connectionType);
             default -> configPrefix + configName;
         };
+    }
+
+    private static String databaseNameConfig(ConnectionEntity.Type connectionType) {
+        if (connectionType == ConnectionEntity.Type.SQLSERVER) {
+            return DEBEZIUM_SQLSERVER_DATABASE_NAME_CONFIG;
+        }
+        return DEBEZIUM_DATABASE_NAME_CONFIG;
     }
 
     private String prefixResolver(ConnectionEntity.Type connectionType) {

--- a/debezium-platform-conductor/src/main/java/io/debezium/platform/environment/operator/PipelineMapper.java
+++ b/debezium-platform-conductor/src/main/java/io/debezium/platform/environment/operator/PipelineMapper.java
@@ -7,8 +7,8 @@ package io.debezium.platform.environment.operator;
 
 import static io.debezium.platform.environment.database.DatabaseConnectionConfiguration.DATABASE;
 import static io.debezium.platform.environment.database.DatabaseConnectionConfiguration.DEBEZIUM_DATABASE_NAME_CONFIG;
-import static io.debezium.platform.environment.database.DatabaseConnectionConfiguration.DEBEZIUM_SQLSERVER_DATABASE_NAME_CONFIG;
 import static io.debezium.platform.environment.database.DatabaseConnectionConfiguration.DEBEZIUM_DATABASE_USERNAME_CONFIG;
+import static io.debezium.platform.environment.database.DatabaseConnectionConfiguration.DEBEZIUM_SQLSERVER_DATABASE_NAME_CONFIG;
 import static io.debezium.platform.environment.database.DatabaseConnectionConfiguration.USERNAME;
 import static io.debezium.platform.environment.database.DatabaseConnectionFactory.DATABASE_CONNECTION_CONFIGURATION_PREFIX;
 

--- a/debezium-platform-conductor/src/test/java/io/debezium/platform/environment/operator/PipelineMapperTest.java
+++ b/debezium-platform-conductor/src/test/java/io/debezium/platform/environment/operator/PipelineMapperTest.java
@@ -6,11 +6,7 @@
 package io.debezium.platform.environment.operator;
 
 import static io.debezium.platform.environment.database.DatabaseConnectionConfiguration.DATABASE;
-import static io.debezium.platform.environment.database.DatabaseConnectionConfiguration.DEBEZIUM_DATABASE_NAME_CONFIG;
-import static io.debezium.platform.environment.database.DatabaseConnectionConfiguration.DEBEZIUM_DATABASE_USERNAME_CONFIG;
-import static io.debezium.platform.environment.database.DatabaseConnectionConfiguration.DEBEZIUM_SQLSERVER_DATABASE_NAME_CONFIG;
 import static io.debezium.platform.environment.database.DatabaseConnectionConfiguration.USERNAME;
-import static io.debezium.platform.environment.database.DatabaseConnectionFactory.DATABASE_CONNECTION_CONFIGURATION_PREFIX;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -74,8 +70,8 @@ public class PipelineMapperTest {
         var result = pipelineMapper.map(pipeline);
 
         assertThat(result.getSpec().getSource().getConfig().getProps())
-                .containsEntry(DATABASE_CONNECTION_CONFIGURATION_PREFIX + DEBEZIUM_SQLSERVER_DATABASE_NAME_CONFIG, "customers")
-                .containsEntry(DATABASE_CONNECTION_CONFIGURATION_PREFIX + DEBEZIUM_DATABASE_USERNAME_CONFIG, "sa");
+                .containsEntry("database.names", "customers")
+                .containsEntry("database.user", "sa");
     }
 
     @Test
@@ -87,8 +83,8 @@ public class PipelineMapperTest {
         var result = pipelineMapper.map(pipeline);
 
         assertThat(result.getSpec().getSource().getConfig().getProps())
-                .containsEntry(DATABASE_CONNECTION_CONFIGURATION_PREFIX + DEBEZIUM_DATABASE_NAME_CONFIG, "customers")
-                .containsEntry(DATABASE_CONNECTION_CONFIGURATION_PREFIX + DEBEZIUM_DATABASE_USERNAME_CONFIG, "sa");
+                .containsEntry("database.dbname", "customers")
+                .containsEntry("database.user", "sa");
     }
 
     private PipelineFlat mockPipelineWithSource(ConnectionEntity.Type type, Map<String, Object> connectionConfig) {

--- a/debezium-platform-conductor/src/test/java/io/debezium/platform/environment/operator/PipelineMapperTest.java
+++ b/debezium-platform-conductor/src/test/java/io/debezium/platform/environment/operator/PipelineMapperTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.platform.environment.operator;
+
+import static io.debezium.platform.environment.database.DatabaseConnectionConfiguration.DATABASE;
+import static io.debezium.platform.environment.database.DatabaseConnectionConfiguration.DEBEZIUM_DATABASE_NAME_CONFIG;
+import static io.debezium.platform.environment.database.DatabaseConnectionConfiguration.DEBEZIUM_DATABASE_USERNAME_CONFIG;
+import static io.debezium.platform.environment.database.DatabaseConnectionConfiguration.DEBEZIUM_SQLSERVER_DATABASE_NAME_CONFIG;
+import static io.debezium.platform.environment.database.DatabaseConnectionConfiguration.USERNAME;
+import static io.debezium.platform.environment.database.DatabaseConnectionFactory.DATABASE_CONNECTION_CONFIGURATION_PREFIX;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import io.debezium.platform.config.OffsetConfigGroup;
+import io.debezium.platform.config.OffsetStorageConfigGroup;
+import io.debezium.platform.config.PipelineConfigGroup;
+import io.debezium.platform.config.SchemaHistoryConfigGroup;
+import io.debezium.platform.data.model.ConnectionEntity;
+import io.debezium.platform.domain.views.Connection;
+import io.debezium.platform.domain.views.flat.DestinationFlat;
+import io.debezium.platform.domain.views.flat.PipelineFlat;
+import io.debezium.platform.domain.views.flat.SourceFlat;
+import io.debezium.platform.environment.operator.configuration.TableNameResolver;
+
+@ExtendWith(MockitoExtension.class)
+public class PipelineMapperTest {
+
+    @Mock
+    PipelineConfigGroup pipelineConfigGroup;
+
+    @Mock
+    TableNameResolver tableNameResolver;
+
+    @Mock
+    private OffsetConfigGroup offsetConfigGroup;
+
+    @Mock
+    private OffsetStorageConfigGroup offsetStorageConfigGroup;
+
+    @Mock
+    private SchemaHistoryConfigGroup schemaHistoryConfigGroup;
+
+    private PipelineMapper pipelineMapper;
+
+    @BeforeEach
+    void setUp() {
+        when(pipelineConfigGroup.offset()).thenReturn(offsetConfigGroup);
+        when(offsetConfigGroup.storage()).thenReturn(offsetStorageConfigGroup);
+        when(pipelineConfigGroup.schema()).thenReturn(schemaHistoryConfigGroup);
+        when(tableNameResolver.resolve(any(), any())).thenAnswer(invocation -> invocation.getArgument(1));
+
+        pipelineMapper = new PipelineMapper(pipelineConfigGroup, tableNameResolver);
+    }
+
+    @Test
+    public void testMapper_ShouldUseNamesForSqlServer() {
+        var pipeline = mockPipelineWithSource(ConnectionEntity.Type.SQLSERVER, Map.of(
+                DATABASE, "customers",
+                USERNAME, "sa"));
+
+        var result = pipelineMapper.map(pipeline);
+
+        assertThat(result.getSpec().getSource().getConfig().getProps())
+                .containsEntry(DATABASE_CONNECTION_CONFIGURATION_PREFIX + DEBEZIUM_SQLSERVER_DATABASE_NAME_CONFIG, "customers")
+                .containsEntry(DATABASE_CONNECTION_CONFIGURATION_PREFIX + DEBEZIUM_DATABASE_USERNAME_CONFIG, "sa");
+    }
+
+    @Test
+    public void testMapper_ShouldUseDbNameForPostgreSql() {
+        var pipeline = mockPipelineWithSource(ConnectionEntity.Type.POSTGRESQL, Map.of(
+                DATABASE, "customers",
+                USERNAME, "sa"));
+
+        var result = pipelineMapper.map(pipeline);
+
+        assertThat(result.getSpec().getSource().getConfig().getProps())
+                .containsEntry(DATABASE_CONNECTION_CONFIGURATION_PREFIX + DEBEZIUM_DATABASE_NAME_CONFIG, "customers")
+                .containsEntry(DATABASE_CONNECTION_CONFIGURATION_PREFIX + DEBEZIUM_DATABASE_USERNAME_CONFIG, "sa");
+    }
+
+    private PipelineFlat mockPipelineWithSource(ConnectionEntity.Type type, Map<String, Object> connectionConfig) {
+        var pipeline = mock(PipelineFlat.class);
+        var source = mock(SourceFlat.class);
+        var destination = mock(DestinationFlat.class);
+        var connection = mock(Connection.class);
+
+        when(connection.getType()).thenReturn(type);
+        when(connection.getConfig()).thenReturn(connectionConfig);
+
+        when(source.getConnection()).thenReturn(connection);
+
+        when(pipeline.getSource()).thenReturn(source);
+        when(pipeline.getDestination()).thenReturn(destination);
+        when(pipeline.getDefaultLogLevel()).thenReturn("INFO");
+        when(pipeline.getLogLevels()).thenReturn(Map.of());
+        when(pipeline.getId()).thenReturn(1L);
+
+        return pipeline;
+    }
+}


### PR DESCRIPTION
Fixes debezium/dbz#1828

## Description
Add SQL Server-specific database name configuration support in `PipelineMapper`.

## PR Checklist
- [X] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [X] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [X] One feature/change per PR unless tightly coupled
- [X] Do a rebase on upstream `main`
