### PR TITLE
debezium/DBZ-1768: Add support for configurable labels on DebeziumServer CR

### DIFF
--- a/debezium-platform-conductor/src/main/java/io/debezium/platform/config/PipelineConfigGroup.java
+++ b/debezium-platform-conductor/src/main/java/io/debezium/platform/config/PipelineConfigGroup.java
@@ -5,6 +5,8 @@
  */
 package io.debezium.platform.config;
 
+import java.util.Map;
+
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
 import io.smallrye.config.ConfigMapping;
@@ -21,4 +23,5 @@ public interface PipelineConfigGroup {
 
     ServerConfigGroup server();
 
+    Map<String, String> labels();
 }

--- a/debezium-platform-conductor/src/main/java/io/debezium/platform/config/ServerConfigGroup.java
+++ b/debezium-platform-conductor/src/main/java/io/debezium/platform/config/ServerConfigGroup.java
@@ -5,11 +5,8 @@
  */
 package io.debezium.platform.config;
 
-import java.util.Map;
 import java.util.Optional;
 
 public interface ServerConfigGroup {
     Optional<String> image();
-
-    Map<String, String> labels();
 }

--- a/debezium-platform-conductor/src/main/java/io/debezium/platform/config/ServerConfigGroup.java
+++ b/debezium-platform-conductor/src/main/java/io/debezium/platform/config/ServerConfigGroup.java
@@ -5,8 +5,11 @@
  */
 package io.debezium.platform.config;
 
+import java.util.Map;
 import java.util.Optional;
 
 public interface ServerConfigGroup {
     Optional<String> image();
+
+    Map<String, String> labels();
 }

--- a/debezium-platform-conductor/src/main/java/io/debezium/platform/environment/operator/PipelineMapper.java
+++ b/debezium-platform-conductor/src/main/java/io/debezium/platform/environment/operator/PipelineMapper.java
@@ -132,7 +132,7 @@ public class PipelineMapper {
     }
 
     private Map<String, String> createLabels(PipelineFlat pipeline) {
-        Map<String, String> labels = new HashMap<>(pipelineConfigGroup.server().labels());
+        Map<String, String> labels = new HashMap<>(pipelineConfigGroup.labels());
         labels.put(OperatorPipelineController.LABEL_DBZ_CONDUCTOR_ID, pipeline.getId().toString());
         return labels;
     }

--- a/debezium-platform-conductor/src/main/java/io/debezium/platform/environment/operator/PipelineMapper.java
+++ b/debezium-platform-conductor/src/main/java/io/debezium/platform/environment/operator/PipelineMapper.java
@@ -125,10 +125,16 @@ public class PipelineMapper {
         return new DebeziumServerBuilder()
                 .withMetadata(new ObjectMetaBuilder()
                         .withName(pipeline.getName())
-                        .withLabels(Map.of(OperatorPipelineController.LABEL_DBZ_CONDUCTOR_ID, pipeline.getId().toString()))
+                        .withLabels(createLabels(pipeline))
                         .build())
                 .withSpec(specBuilder.build())
                 .build();
+    }
+
+    private Map<String, String> createLabels(PipelineFlat pipeline) {
+        Map<String, String> labels = new HashMap<>(pipelineConfigGroup.server().labels());
+        labels.put(OperatorPipelineController.LABEL_DBZ_CONDUCTOR_ID, pipeline.getId().toString());
+        return labels;
     }
 
     private Quarkus createQuarkus(PipelineFlat pipeline) {

--- a/debezium-platform-conductor/src/main/resources/application.yml
+++ b/debezium-platform-conductor/src/main/resources/application.yml
@@ -51,6 +51,7 @@ pipeline:
                 name: "@{pipeline_name}_schema_history"
   server:
     image: ${PIPELINE_SERVER_IMAGE:}
+    labels: {}
 sources:
   database:
     connection:

--- a/debezium-platform-conductor/src/main/resources/application.yml
+++ b/debezium-platform-conductor/src/main/resources/application.yml
@@ -49,9 +49,9 @@ pipeline:
             history:
               table:
                 name: "@{pipeline_name}_schema_history"
+  labels: {}
   server:
     image: ${PIPELINE_SERVER_IMAGE:}
-    labels: {}
 sources:
   database:
     connection:

--- a/debezium-platform-conductor/src/test/java/io/debezium/platform/environment/operator/PipelineMapperTest.java
+++ b/debezium-platform-conductor/src/test/java/io/debezium/platform/environment/operator/PipelineMapperTest.java
@@ -45,7 +45,7 @@ public class PipelineMapperTest {
     void setUp() {
 
         when(tableNameResolver.resolve(any(), any())).thenAnswer(invocation -> invocation.getArgument(1));
-        when(pipelineConfigGroup.server().labels()).thenReturn(Map.of());
+        when(pipelineConfigGroup.labels()).thenReturn(Map.of());
 
         pipelineMapper = new PipelineMapper(pipelineConfigGroup, tableNameResolver);
     }
@@ -78,7 +78,7 @@ public class PipelineMapperTest {
 
     @Test
     public void testMapper_ShouldMergeConfiguredLabelsWithConductorLabel() {
-        when(pipelineConfigGroup.server().labels()).thenReturn(Map.of("argocd.argoproj.io/instance", "debezium-platform"));
+        when(pipelineConfigGroup.labels()).thenReturn(Map.of("argocd.argoproj.io/instance", "debezium-platform"));
 
         var pipeline = mockPipelineWithSource(ConnectionEntity.Type.POSTGRESQL, Map.of(
                 DATABASE, "customers",

--- a/debezium-platform-conductor/src/test/java/io/debezium/platform/environment/operator/PipelineMapperTest.java
+++ b/debezium-platform-conductor/src/test/java/io/debezium/platform/environment/operator/PipelineMapperTest.java
@@ -7,6 +7,7 @@ package io.debezium.platform.environment.operator;
 
 import static io.debezium.platform.environment.database.DatabaseConnectionConfiguration.DATABASE;
 import static io.debezium.platform.environment.database.DatabaseConnectionConfiguration.USERNAME;
+import static io.debezium.platform.environment.operator.OperatorPipelineController.LABEL_DBZ_CONDUCTOR_ID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -44,6 +45,7 @@ public class PipelineMapperTest {
     void setUp() {
 
         when(tableNameResolver.resolve(any(), any())).thenAnswer(invocation -> invocation.getArgument(1));
+        when(pipelineConfigGroup.server().labels()).thenReturn(Map.of());
 
         pipelineMapper = new PipelineMapper(pipelineConfigGroup, tableNameResolver);
     }
@@ -72,6 +74,22 @@ public class PipelineMapperTest {
         assertThat(result.getSpec().getSource().getConfig().getProps())
                 .containsEntry("database.dbname", "customers")
                 .containsEntry("database.user", "sa");
+    }
+
+    @Test
+    public void testMapper_ShouldMergeConfiguredLabelsWithConductorLabel() {
+        when(pipelineConfigGroup.server().labels()).thenReturn(Map.of("argocd.argoproj.io/instance", "debezium-platform"));
+
+        var pipeline = mockPipelineWithSource(ConnectionEntity.Type.POSTGRESQL, Map.of(
+                DATABASE, "customers",
+                USERNAME, "sa"));
+        when(pipeline.getName()).thenReturn("pipeline-a");
+
+        var result = pipelineMapper.map(pipeline);
+
+        assertThat(result.getMetadata().getLabels())
+                .containsEntry("argocd.argoproj.io/instance", "debezium-platform")
+                .containsEntry(LABEL_DBZ_CONDUCTOR_ID, "1");
     }
 
     private PipelineFlat mockPipelineWithSource(ConnectionEntity.Type type, Map<String, Object> connectionConfig) {

--- a/helm/README.md
+++ b/helm/README.md
@@ -60,6 +60,7 @@ you `values.yaml` with your domain.
 | schemaHistory.database.auth.username       | Database username                                                                                                                                                                      | user                                       |
 | schemaHistory.database.auth.password       | Database password                                                                                                                                                                      | password                                   |                                                                                                                                                                       |                                                                                                                                                                                 |                                             |
 | env                                        | List of env variable to pass to the conductor                                                                                                                                          | []                                         |
+| pipeline.labels                            | Map of labels to apply to DebeziumServer custom resources created by pipelines. These labels are merged with the internal `debezium.io/conductor-id` label.                            | {}                                         |
 
 ## Descriptor OCI Artifacts
 
@@ -156,6 +157,23 @@ server:
   server:
     image: ""  # Operator's ServerImageProvider determines the image
   ```
+
+## Pipeline Labels
+
+You can configure labels that will be applied to all DebeziumServer custom resources created by pipelines. These labels are merged with the internal `debezium.io/conductor-id` label that is always set automatically.
+
+This is useful for integrating with tools like ArgoCD that rely on labels to track and group resources.
+
+### Configuration
+
+```yaml
+pipeline:
+  labels:
+    argocd.argoproj.io/instance: debezium-platform
+    team: data-engineering
+```
+
+The labels are automatically converted to environment variables for the Conductor pod (e.g., `PIPELINE_LABELS_ARGOCD_ARGOPROJ_IO_INSTANCE`).
 
 # Install
 

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -106,3 +106,12 @@ Get the domain URL, with backward compatibility to deprecated .Values.domain.url
 {{- define "debezium-platform.domainName" -}}
 {{ default .Values.domain.name .Values.domain.url }}
 {{- end -}}
+
+{{/*
+Converts a key to an environment variable name with a given prefix.
+Usage: include "debezium-platform.toEnv" (dict "prefix" "PIPELINE_LABELS" "key" "argocd.argoproj.io/instance")
+Result: PIPELINE_LABELS_ARGOCD_ARGOPROJ_IO_INSTANCE
+*/}}
+{{- define "debezium-platform.toEnv" -}}
+{{ .prefix }}_{{ .key | upper | replace "." "_" | replace "/" "_" | replace "-" "_" }}
+{{- end -}}

--- a/helm/templates/conductor-deployment.yaml
+++ b/helm/templates/conductor-deployment.yaml
@@ -73,4 +73,8 @@ spec:
             - name: {{ .name }}
               value: {{ .value }}
 {{- end }}
+{{- range $key, $value := .Values.pipeline.labels }}
+            - name: PIPELINE_LABELS_{{ $key | upper | replace "." "_" | replace "/" "_" | replace "-" "_" }}
+              value: {{ $value | quote }}
+{{- end }}
       restartPolicy: Always

--- a/helm/templates/conductor-deployment.yaml
+++ b/helm/templates/conductor-deployment.yaml
@@ -74,7 +74,7 @@ spec:
               value: {{ .value }}
 {{- end }}
 {{- range $key, $value := .Values.pipeline.labels }}
-            - name: PIPELINE_LABELS_{{ $key | upper | replace "." "_" | replace "/" "_" | replace "-" "_" }}
+            - name: {{ include "debezium-platform.toEnv" (dict "prefix" "PIPELINE_LABELS" "key" $key) | trim }}
               value: {{ $value | quote }}
 {{- end }}
       restartPolicy: Always

--- a/helm/tests/conductor_test.yaml
+++ b/helm/tests/conductor_test.yaml
@@ -258,3 +258,18 @@ tests:
       - equal:
           path: spec.rules[0].host
           value: legacy.example.com
+
+  - it: should configure pipeline labels via env variables
+    template: conductor-deployment.yaml
+    set:
+      env:
+        - name: PIPELINE_LABELS_ARGOCD_ARGOPROJ_IO_INSTANCE
+          value: debezium-platform
+    asserts:
+      - isKind:
+          of: Deployment
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: PIPELINE_LABELS_ARGOCD_ARGOPROJ_IO_INSTANCE
+            value: debezium-platform

--- a/helm/tests/conductor_test.yaml
+++ b/helm/tests/conductor_test.yaml
@@ -262,9 +262,8 @@ tests:
   - it: should configure pipeline labels via env variables
     template: conductor-deployment.yaml
     set:
-      env:
-        - name: PIPELINE_LABELS_ARGOCD_ARGOPROJ_IO_INSTANCE
-          value: debezium-platform
+      pipeline.labels:
+        argocd.argoproj.io/instance: debezium-platform
     asserts:
       - isKind:
           of: Deployment
@@ -272,4 +271,4 @@ tests:
           path: spec.template.spec.containers[0].env
           content:
             name: PIPELINE_LABELS_ARGOCD_ARGOPROJ_IO_INSTANCE
-            value: debezium-platform
+            value: "debezium-platform"

--- a/helm/values.schema.json
+++ b/helm/values.schema.json
@@ -196,6 +196,19 @@
             },
             "type": "object"
         },
+        "pipeline": {
+            "type": "object",
+            "properties": {
+                "labels": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    },
+                    "default": {},
+                    "description": "Map of labels to apply to DebeziumServer custom resources created by pipelines"
+                }
+            }
+        },
         "ingress": {
           "type": "object",
           "properties": {

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -53,4 +53,6 @@ database:
     existingSecret: ""
 debezium-operator:
   enabled: true
+pipeline:
+  labels: {}
 env: []


### PR DESCRIPTION
## Summary

Currently, when Conductor creates the DebeziumServer Custom Resource, it only sets one hardcoded label (`debezium.io/conductor-id`). There is no way for users to pass additional labels to the CR, which makes it impossible to group or track resources in tools like ArgoCD.

This PR adds support for configurable labels on the DebeziumServer CR via the pipeline server config.

## Changes

- Added `labels()` method to `ServerConfigGroup` interface
- Updated `PipelineMapper` to extract label building into a `createLabels()` method that merges user-configured labels with the internal `debezium.io/conductor-id` label
- Added `labels: {}` as default empty map in `application.yml`
- Added test coverage for label merging behavior in `PipelineMapperTest`

## Usage

Users can now configure labels via `application.yml` or environment variables:

```yaml
pipeline:
  server:
    labels:
      argocd.argoproj.io/instance: debezium-platform
```
      
## Note

A follow-up issue may be required to be created to track Option C - supporting per-pipeline labels via the API in addition to the config-level labels added here.

Fixes [#1768](https://github.com/debezium/dbz/issues/1768)