### PR TITLE
debezium/dbz#1994: Add support for configuring extra volumes and volume mounts for the Conductor deployment in Helm chart

### DIFF
--- a/helm/README.md
+++ b/helm/README.md
@@ -37,6 +37,8 @@ you `values.yaml` with your domain.
 | conductor.descriptors.official.image       | Image name for the descriptor OCI artifact                                                                                                                                             | debezium/debezium-descriptors              |
 | conductor.descriptors.official.tag         | Image tag for the descriptor OCI artifact                                                                                                                                              | nightly                                    |
 | conductor.descriptors.official.mountPath   | Path where descriptors will be downloaded inside the container                                                                                                                         | /opt/descriptors                           |
+| conductor.extraVolumes                     | Extra volumes to add to the conductor deployment                                                                                                                                       | []                                         |
+| conductor.extraVolumeMounts                | Extra volume mounts to add to the conductor container                                                                                                                                  | []                                         |
 | server.image                               | Image for Debezium Server instances created by pipelines. If empty, the operator's ServerImageProvider determines the image                                                            | ""                                         |
 | database.enabled                           | Enable the installation of PostgreSQL by the chart                                                                                                                                     | false                                      |
 | database.name                              | Database name                                                                                                                                                                          | postgres                                   |
@@ -126,6 +128,22 @@ debezium-descriptors:nightly
 ```
 
 The artifact contents are extracted to the configured `mountPath`.
+
+## Extra Conductor Volumes
+
+Additional volumes and volume mounts can be configured for the conductor container. This can be used, for example, to mount a ConfigMap containing a custom truststore.
+
+```yaml
+conductor:
+  extraVolumes: 
+    - name: truststore 
+      configMap: 
+        name: conductor-truststore
+  extraVolumeMounts: 
+    - name: truststore 
+      mountPath: /etc/truststore 
+      readOnly: true
+```
 
 ## Debezium Server Image Configuration
 

--- a/helm/templates/conductor-deployment.yaml
+++ b/helm/templates/conductor-deployment.yaml
@@ -31,7 +31,7 @@ spec:
               protocol: TCP
 {{- with .Values.conductor.extraVolumeMounts }}
           volumeMounts:
-{{ toYaml . | indent 16 }}
+{{ toYaml . | indent 12 }}
 {{- end }}
           env:
             - name: QUARKUS_DATASOURCE_PASSWORD
@@ -83,6 +83,6 @@ spec:
 {{- end }}
 {{- with .Values.conductor.extraVolumes }}
       volumes:
-{{ toYaml . | indent 12 }}
+{{ toYaml . | indent 8 }}
 {{- end }}
       restartPolicy: Always

--- a/helm/templates/conductor-deployment.yaml
+++ b/helm/templates/conductor-deployment.yaml
@@ -29,6 +29,10 @@ spec:
           ports:
             - containerPort: 8080
               protocol: TCP
+{{- with .Values.conductor.extraVolumeMounts }}
+          volumeMounts:
+{{ toYaml . | indent 16 }}
+{{- end }}
           env:
             - name: QUARKUS_DATASOURCE_PASSWORD
               valueFrom:
@@ -76,5 +80,9 @@ spec:
 {{- range $key, $value := .Values.pipeline.labels }}
             - name: {{ include "debezium-platform.toEnv" (dict "prefix" "PIPELINE_LABELS" "key" $key) | trim }}
               value: {{ $value | quote }}
+{{- end }}
+{{- with .Values.conductor.extraVolumes }}
+      volumes:
+{{ toYaml . | indent 12 }}
 {{- end }}
       restartPolicy: Always

--- a/helm/tests/conductor_test.yaml
+++ b/helm/tests/conductor_test.yaml
@@ -272,3 +272,30 @@ tests:
           content:
             name: PIPELINE_LABELS_ARGOCD_ARGOPROJ_IO_INSTANCE
             value: "debezium-platform"
+
+  - it: should add extra volumes and volume mounts to conductor deployment
+    template: conductor-deployment.yaml
+    set:
+      conductor.extraVolumes:
+        - name: truststore
+          configMap:
+            name: conductor-truststore
+      conductor.extraVolumeMounts:
+        - name: truststore
+          mountPath: /etc/truststore
+          readOnly: true
+    asserts:
+      - isKind:
+          of: Deployment
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: truststore
+            configMap:
+              name: conductor-truststore
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: truststore
+            mountPath: /etc/truststore
+            readOnly: true

--- a/helm/values.schema.json
+++ b/helm/values.schema.json
@@ -53,6 +53,14 @@
                             "required": ["enabled", "registry", "image", "tag", "mountPath"]
                         }
                     }
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "default": []
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "default": []
                 }
             },
             "type": "object"

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -16,6 +16,8 @@ conductor:
       image: debezium/debezium-descriptors
       tag: nightly
       mountPath: /opt/descriptors
+  extraVolumes: [ ]
+  extraVolumeMounts: [ ]
 server:
   image: ""
 ingress:


### PR DESCRIPTION
<!-- Make sure all your commits are signed before submitting your pull request -->
<!-- Run `git commit -s` to sign off your commits to satisfy the DCO check -->
<!-- Ensure your commit messages start with your GitHub issue, e.g., debezium/dbz#<issue_number> -->
Fixes debezium/dbz#1994

## Description

This PR adds support for configuring extra volumes and volume mounts on the Debezium Platform conductor deployment.

This allows users to mount additional Kubernetes resources, such as a ConfigMap containing a custom truststore, into the conductor container.

The new chart values are documented and covered by Helm unit tests.

## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [X] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [X] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [X] One feature/change per PR unless tightly coupled
- [X] Do a rebase on upstream `main`
