### PR TITLE
debezium/dbz#2027 Enable heartbeat to prevent WAL growing

### DIFF
--- a/debezium-platform-conductor/src/main/java/io/debezium/platform/environment/watcher/ConductorEnvironmentWatcher.java
+++ b/debezium-platform-conductor/src/main/java/io/debezium/platform/environment/watcher/ConductorEnvironmentWatcher.java
@@ -17,8 +17,6 @@ import jakarta.annotation.PostConstruct;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.event.Observes;
 
-import org.jboss.logging.Logger;
-
 import io.debezium.config.Configuration;
 import io.debezium.connector.postgresql.PostgresConnector;
 import io.debezium.connector.postgresql.PostgresConnectorConfig;
@@ -26,6 +24,8 @@ import io.debezium.connector.postgresql.PostgresConnectorConfig.AutoCreateMode;
 import io.debezium.embedded.Connect;
 import io.debezium.embedded.EmbeddedEngineConfig;
 import io.debezium.engine.DebeziumEngine;
+import io.debezium.heartbeat.DatabaseHeartbeatImpl;
+import io.debezium.heartbeat.Heartbeat;
 import io.debezium.platform.config.OffsetConfigGroup;
 import io.debezium.platform.environment.watcher.config.WatcherConfig;
 import io.debezium.platform.environment.watcher.consumers.OutboxParentEventConsumer;
@@ -37,10 +37,16 @@ import io.quarkus.runtime.Startup;
 @Startup
 public class ConductorEnvironmentWatcher {
 
+    private static final org.slf4j.Logger LOGGER = org.slf4j.LoggerFactory.getLogger(ConductorEnvironmentWatcher.class);
+
     public static final String CONFIG_PORTION = "\\.config";
     public static final String OFFSET_STORAGE_PREFIX = "offset.storage.";
     public static final String OFFSET_PREFIX = "offset.";
-    private final Logger logger;
+    private static final String HEARTBEAT_DEFAULT_ACTION_QUERY = """
+            INSERT INTO public.heartbeat (id, timestamp) \
+            VALUES (1, now()) \
+            ON CONFLICT (id) DO UPDATE SET timestamp = now()\
+            """;
     private final OutboxParentEventConsumer eventConsumer;
     private final WatcherConfig watcherConfig;
     private final ExecutorService executor = Executors.newSingleThreadExecutor();
@@ -60,7 +66,8 @@ public class ConductorEnvironmentWatcher {
         }
 
         var connection = watcherConfig.connection();
-        var offset = watcherConfig.watcher().offset();
+        var watcher = watcherConfig.watcher();
+        var offset = watcher.offset();
         var outbox = watcherConfig.outbox();
         var extraFields = Stream.of(outbox.aggregateColumn(), outbox.aggregateIdColumn(), outbox.typeColumn())
                 .map(c -> c + ":envelope")
@@ -77,11 +84,18 @@ public class ConductorEnvironmentWatcher {
                 .with(PostgresConnectorConfig.DATABASE_NAME, connection.database())
                 .with(PostgresConnectorConfig.PLUGIN_NAME, PostgresConnectorConfig.LogicalDecoder.PGOUTPUT.getValue())
                 .with(PostgresConnectorConfig.INCLUDE_SCHEMA_CHANGES, false)
-                .with(PostgresConnectorConfig.TABLE_INCLUDE_LIST, "public.%s".formatted(outbox.table()))
+                .with(PostgresConnectorConfig.TABLE_INCLUDE_LIST, "public.%s,public.heartbeat".formatted(outbox.table()))
                 .with(PostgresConnectorConfig.PUBLICATION_AUTOCREATE_MODE, AutoCreateMode.FILTERED)
+                .with(Heartbeat.HEARTBEAT_INTERVAL_PROPERTY_NAME, watcher.heartbeat().intervalMs())
+                .with(DatabaseHeartbeatImpl.HEARTBEAT_ACTION_QUERY_PROPERTY_NAME,
+                        watcher.heartbeat().actionQuery().orElse(HEARTBEAT_DEFAULT_ACTION_QUERY))
                 .with("transforms", "outbox")
                 .with("transforms.outbox.type", EventRouter.class.getName())
-                .with("transforms.outbox.table.fields.additional.placement", extraFields);
+                .with("transforms.outbox.table.fields.additional.placement", extraFields)
+                .with("transforms.outbox.predicate", "isOutboxTable")
+                .with("predicates", "isOutboxTable")
+                .with("predicates.isOutboxTable.type", "org.apache.kafka.connect.transforms.predicates.TopicNameMatches")
+                .with("predicates.isOutboxTable.pattern", ".*\\.%s".formatted(outbox.table()));
 
         offsetConfigurations(offset).forEach(configurationBuilder::with);
 
@@ -90,6 +104,14 @@ public class ConductorEnvironmentWatcher {
         logger.info("Creating Debezium engine");
         this.engine = DebeziumEngine.create(Connect.class)
                 .using(config.asProperties())
+                .using((success, message, error) -> {
+                    if (error != null) {
+                        logger.errorf(error, "Debezium engine stopped with error: %s", message);
+                    }
+                    else {
+                        logger.infof("Debezium engine stopped: success=%s, message=%s", success, message);
+                    }
+                })
                 .notifying(eventConsumer)
                 .build();
 

--- a/debezium-platform-conductor/src/main/java/io/debezium/platform/environment/watcher/ConductorEnvironmentWatcher.java
+++ b/debezium-platform-conductor/src/main/java/io/debezium/platform/environment/watcher/ConductorEnvironmentWatcher.java
@@ -17,6 +17,9 @@ import jakarta.annotation.PostConstruct;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.event.Observes;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import io.debezium.config.Configuration;
 import io.debezium.connector.postgresql.PostgresConnector;
 import io.debezium.connector.postgresql.PostgresConnectorConfig;
@@ -37,7 +40,7 @@ import io.quarkus.runtime.Startup;
 @Startup
 public class ConductorEnvironmentWatcher {
 
-    private static final org.slf4j.Logger LOGGER = org.slf4j.LoggerFactory.getLogger(ConductorEnvironmentWatcher.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(ConductorEnvironmentWatcher.class);
 
     public static final String CONFIG_PORTION = "\\.config";
     public static final String OFFSET_STORAGE_PREFIX = "offset.storage.";
@@ -52,8 +55,7 @@ public class ConductorEnvironmentWatcher {
     private final ExecutorService executor = Executors.newSingleThreadExecutor();
     private DebeziumEngine<?> engine;
 
-    public ConductorEnvironmentWatcher(Logger logger, WatcherConfig watcherConfig, OutboxParentEventConsumer eventConsumer) {
-        this.logger = logger;
+    public ConductorEnvironmentWatcher(WatcherConfig watcherConfig, OutboxParentEventConsumer eventConsumer) {
         this.watcherConfig = watcherConfig;
         this.eventConsumer = eventConsumer;
     }
@@ -61,7 +63,7 @@ public class ConductorEnvironmentWatcher {
     @PostConstruct
     public void start() {
         if (!watcherConfig.watcher().enabled()) {
-            logger.info("Skipping watcher because it is not enabled");
+            LOGGER.info("Skipping watcher because it is not enabled");
             return;
         }
 
@@ -101,21 +103,21 @@ public class ConductorEnvironmentWatcher {
 
         var config = configurationBuilder.build();
 
-        logger.info("Creating Debezium engine");
+        LOGGER.info("Creating Debezium engine");
         this.engine = DebeziumEngine.create(Connect.class)
                 .using(config.asProperties())
                 .using((success, message, error) -> {
                     if (error != null) {
-                        logger.errorf(error, "Debezium engine stopped with error: %s", message);
+                        LOGGER.error("Debezium engine stopped with error: %s".formatted(message), error);
                     }
                     else {
-                        logger.infof("Debezium engine stopped: success=%s, message=%s", success, message);
+                        LOGGER.info("Debezium engine stopped: success={}, message={}", success, message);
                     }
                 })
                 .notifying(eventConsumer)
                 .build();
 
-        logger.info("Attempting to start debezium engine");
+        LOGGER.info("Attempting to start debezium engine");
         executor.execute(engine);
     }
 
@@ -143,13 +145,13 @@ public class ConductorEnvironmentWatcher {
         }
 
         try {
-            logger.info("Attempting to stop Debezium");
+            LOGGER.info("Attempting to stop Debezium");
             engine.close();
             executor.shutdown();
             executor.awaitTermination(10, TimeUnit.SECONDS);
         }
         catch (Exception e) {
-            logger.error("Exception while shutting down Debezium", e);
+            LOGGER.error("Exception while shutting down Debezium", e);
         }
     }
 }

--- a/debezium-platform-conductor/src/main/java/io/debezium/platform/environment/watcher/ConductorEnvironmentWatcher.java
+++ b/debezium-platform-conductor/src/main/java/io/debezium/platform/environment/watcher/ConductorEnvironmentWatcher.java
@@ -10,6 +10,7 @@ import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -97,7 +98,7 @@ public class ConductorEnvironmentWatcher {
                 .with("transforms.outbox.predicate", "isOutboxTable")
                 .with("predicates", "isOutboxTable")
                 .with("predicates.isOutboxTable.type", "org.apache.kafka.connect.transforms.predicates.TopicNameMatches")
-                .with("predicates.isOutboxTable.pattern", ".*\\.%s".formatted(outbox.table()));
+                .with("predicates.isOutboxTable.pattern", ".*\\.%s".formatted(Pattern.quote(outbox.table())));
 
         offsetConfigurations(offset).forEach(configurationBuilder::with);
 

--- a/debezium-platform-conductor/src/main/java/io/debezium/platform/environment/watcher/ConductorEnvironmentWatcher.java
+++ b/debezium-platform-conductor/src/main/java/io/debezium/platform/environment/watcher/ConductorEnvironmentWatcher.java
@@ -90,8 +90,7 @@ public class ConductorEnvironmentWatcher {
                 .with(PostgresConnectorConfig.TABLE_INCLUDE_LIST, "public.%s,public.heartbeat".formatted(outbox.table()))
                 .with(PostgresConnectorConfig.PUBLICATION_AUTOCREATE_MODE, AutoCreateMode.FILTERED)
                 .with(Heartbeat.HEARTBEAT_INTERVAL_PROPERTY_NAME, watcher.heartbeat().intervalMs())
-                .with(DatabaseHeartbeatImpl.HEARTBEAT_ACTION_QUERY_PROPERTY_NAME,
-                        watcher.heartbeat().actionQuery().orElse(HEARTBEAT_DEFAULT_ACTION_QUERY))
+                .with(DatabaseHeartbeatImpl.HEARTBEAT_ACTION_QUERY_PROPERTY_NAME, HEARTBEAT_DEFAULT_ACTION_QUERY)
                 .with("transforms", "outbox")
                 .with("transforms.outbox.type", EventRouter.class.getName())
                 .with("transforms.outbox.table.fields.additional.placement", extraFields)

--- a/debezium-platform-conductor/src/main/java/io/debezium/platform/environment/watcher/config/WatcherConfigGroup.java
+++ b/debezium-platform-conductor/src/main/java/io/debezium/platform/environment/watcher/config/WatcherConfigGroup.java
@@ -11,6 +11,7 @@ import io.debezium.platform.config.OffsetConfigGroup;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
 import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithName;
 
 @ConfigMapping(prefix = "conductor.watcher")
 @ConfigRoot(phase = ConfigPhase.RUN_TIME)
@@ -21,5 +22,16 @@ public interface WatcherConfigGroup {
     Optional<String> crd();
 
     OffsetConfigGroup offset();
+
+    HeartbeatConfig heartbeat();
+
+    interface HeartbeatConfig {
+
+        @WithName("interval-ms")
+        int intervalMs();
+
+        @WithName("action-query")
+        Optional<String> actionQuery();
+    }
 
 }

--- a/debezium-platform-conductor/src/main/java/io/debezium/platform/environment/watcher/config/WatcherConfigGroup.java
+++ b/debezium-platform-conductor/src/main/java/io/debezium/platform/environment/watcher/config/WatcherConfigGroup.java
@@ -30,8 +30,6 @@ public interface WatcherConfigGroup {
         @WithName("interval-ms")
         int intervalMs();
 
-        @WithName("action-query")
-        Optional<String> actionQuery();
     }
 
 }

--- a/debezium-platform-conductor/src/main/java/io/debezium/platform/environment/watcher/consumers/OutboxParentEventConsumer.java
+++ b/debezium-platform-conductor/src/main/java/io/debezium/platform/environment/watcher/consumers/OutboxParentEventConsumer.java
@@ -12,7 +12,8 @@ import jakarta.enterprise.inject.Instance;
 
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.source.SourceRecord;
-import org.jboss.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import io.debezium.engine.ChangeEvent;
 import io.debezium.platform.environment.watcher.config.OutboxConfigGroup;
@@ -29,12 +30,12 @@ import io.debezium.platform.environment.watcher.config.OutboxConfigGroup;
 @Dependent
 public final class OutboxParentEventConsumer implements Consumer<ChangeEvent<SourceRecord, SourceRecord>> {
 
-    private final Logger logger;
+    private static final Logger LOGGER = LoggerFactory.getLogger(OutboxParentEventConsumer.class);
+
     private final OutboxConfigGroup outbox;
     private final Instance<EnvironmentEventConsumer<?>> eventConsumers;
 
-    public OutboxParentEventConsumer(Logger logger, OutboxConfigGroup outbox, Instance<EnvironmentEventConsumer<?>> eventConsumers) {
-        this.logger = logger;
+    public OutboxParentEventConsumer(OutboxConfigGroup outbox, Instance<EnvironmentEventConsumer<?>> eventConsumers) {
         this.outbox = outbox;
         this.eventConsumers = eventConsumers;
     }
@@ -43,12 +44,16 @@ public final class OutboxParentEventConsumer implements Consumer<ChangeEvent<Sou
     public void accept(ChangeEvent<SourceRecord, SourceRecord> event) {
         var value = (Struct) event.value().value();
 
+        if (value == null || value.schema().field(outbox.aggregateColumn()) == null) {
+            return;
+        }
+
         var aggregateType = value.getString(outbox.aggregateColumn());
         var aggregateId = value.getString(outbox.aggregateIdColumn());
         var eventType = value.getString(outbox.typeColumn());
         var payload = value.getString("payload");
 
-        logger.debugf("Consumed %s event for %s (#%s) with payload %s", eventType, aggregateType, aggregateId, payload);
+        LOGGER.debug("Consumed {} event for {} (#{}) with payload {}", eventType, aggregateType, aggregateId, payload);
 
         eventConsumers.forEach(consumer -> consumer.consume(
                 aggregateType, eventType, Long.valueOf(aggregateId), payload));

--- a/debezium-platform-conductor/src/main/resources/application.yml
+++ b/debezium-platform-conductor/src/main/resources/application.yml
@@ -1,6 +1,8 @@
 conductor:
   watcher:
     enabled: true
+    heartbeat:
+      interval-ms: 300000
     offset:
       storage:
         type: org.apache.kafka.connect.storage.FileOffsetBackingStore

--- a/debezium-platform-conductor/src/main/resources/db/migration/V3.6.0__create_heartbeat_table.sql
+++ b/debezium-platform-conductor/src/main/resources/db/migration/V3.6.0__create_heartbeat_table.sql
@@ -1,0 +1,4 @@
+CREATE TABLE IF NOT EXISTS heartbeat (
+    id INTEGER PRIMARY KEY,
+    timestamp TIMESTAMP NOT NULL DEFAULT now()
+);

--- a/debezium-platform-conductor/src/test/java/io/debezium/platform/HeartbeatTestProfile.java
+++ b/debezium-platform-conductor/src/test/java/io/debezium/platform/HeartbeatTestProfile.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.platform;
+
+import java.util.Map;
+
+public class HeartbeatTestProfile extends OutboxTestProfile {
+
+    @Override
+    public Map<String, String> getConfigOverrides() {
+        return Map.of("conductor.watcher.heartbeat.interval-ms", "2000");
+    }
+}

--- a/debezium-platform-conductor/src/test/java/io/debezium/platform/api/HeartbeatWalAdvancementIT.java
+++ b/debezium-platform-conductor/src/test/java/io/debezium/platform/api/HeartbeatWalAdvancementIT.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.platform.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.shaded.org.awaitility.Awaitility;
+
+import io.agroal.api.AgroalDataSource;
+import io.debezium.platform.HeartbeatTestProfile;
+import io.debezium.platform.environment.operator.actions.DebeziumKubernetesAdapter;
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.quarkus.arc.InjectableInstance;
+import io.quarkus.test.InjectMock;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+
+@QuarkusTest
+@TestProfile(HeartbeatTestProfile.class)
+@EnableKubernetesMockClient(crud = true)
+class HeartbeatWalAdvancementIT {
+
+    @Inject
+    InjectableInstance<AgroalDataSource> dataSource;
+
+    @InjectMock
+    DebeziumKubernetesAdapter k8sAdapter;
+
+    @Test
+    @DisplayName("Heartbeat should cause the replication slot confirmed_flush_lsn to advance")
+    void heartbeatShouldAdvanceReplicationSlotLsn() throws Exception {
+        var initialLsn = new AtomicReference<String>();
+
+        Awaitility.await()
+                .alias("replication slot should be created")
+                .atMost(30, TimeUnit.SECONDS)
+                .pollInterval(1, TimeUnit.SECONDS)
+                .untilAsserted(() -> {
+                    try (Connection conn = dataSource.get().getConnection();
+                            Statement stmt = conn.createStatement();
+                            ResultSet rs = stmt.executeQuery("""
+                                    SELECT confirmed_flush_lsn
+                                    FROM pg_replication_slots
+                                    WHERE slot_name = 'debezium'
+                                    """)) {
+                        assertThat(rs.next())
+                                .as("Replication slot 'debezium' should exist")
+                                .isTrue();
+                        initialLsn.set(rs.getString("confirmed_flush_lsn"));
+                        assertThat(initialLsn.get()).isNotNull();
+                    }
+                });
+
+        Awaitility.await()
+                .alias("heartbeat row should be inserted")
+                .atMost(30, TimeUnit.SECONDS)
+                .pollInterval(1, TimeUnit.SECONDS)
+                .untilAsserted(() -> {
+                    try (Connection conn = dataSource.get().getConnection();
+                            Statement stmt = conn.createStatement();
+                            ResultSet rs = stmt.executeQuery("SELECT id FROM heartbeat WHERE id = 1")) {
+                        assertThat(rs.next())
+                                .as("Heartbeat row should exist")
+                                .isTrue();
+                    }
+                });
+
+        Awaitility.await()
+                .alias("confirmed_flush_lsn should advance past initial value")
+                .atMost(60, TimeUnit.SECONDS)
+                .pollInterval(2, TimeUnit.SECONDS)
+                .untilAsserted(() -> {
+                    try (Connection conn = dataSource.get().getConnection();
+                            Statement stmt = conn.createStatement();
+                            ResultSet rs = stmt.executeQuery("""
+                                    SELECT confirmed_flush_lsn
+                                    FROM pg_replication_slots
+                                    WHERE slot_name = 'debezium'
+                                    """)) {
+                        assertThat(rs.next()).isTrue();
+                        var currentLsn = rs.getString("confirmed_flush_lsn");
+                        assertThat(currentLsn)
+                                .as("confirmed_flush_lsn should advance from %s", initialLsn.get())
+                                .isNotEqualTo(initialLsn.get());
+                    }
+                });
+    }
+}

--- a/debezium-platform-conductor/src/test/java/io/debezium/platform/api/HeartbeatWalAdvancementIT.java
+++ b/debezium-platform-conductor/src/test/java/io/debezium/platform/api/HeartbeatWalAdvancementIT.java
@@ -15,9 +15,9 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import jakarta.inject.Inject;
 
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.testcontainers.shaded.org.awaitility.Awaitility;
 
 import io.agroal.api.AgroalDataSource;
 import io.debezium.platform.HeartbeatTestProfile;

--- a/debezium-platform-conductor/src/test/java/io/debezium/platform/api/PipelineResourceIT.java
+++ b/debezium-platform-conductor/src/test/java/io/debezium/platform/api/PipelineResourceIT.java
@@ -16,6 +16,7 @@ import java.util.stream.Stream;
 
 import jakarta.inject.Inject;
 
+import org.awaitility.Awaitility;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -25,7 +26,6 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
-import org.testcontainers.shaded.org.awaitility.Awaitility;
 
 import io.debezium.doc.FixFor;
 import io.debezium.operator.api.model.DebeziumServer;

--- a/debezium-platform-conductor/src/test/java/io/debezium/platform/environment/connection/DatabaseConnectionValidatorIT.java
+++ b/debezium-platform-conductor/src/test/java/io/debezium/platform/environment/connection/DatabaseConnectionValidatorIT.java
@@ -13,11 +13,11 @@ import java.util.stream.Stream;
 
 import jakarta.inject.Inject;
 
+import org.awaitility.Awaitility;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.testcontainers.containers.JdbcDatabaseContainer;
-import org.testcontainers.shaded.org.awaitility.Awaitility;
 
 import io.debezium.platform.data.model.ConnectionEntity;
 import io.debezium.platform.domain.views.Connection;

--- a/debezium-platform-conductor/src/test/java/io/debezium/platform/environment/connection/PulsarConnectionValidatorIT.java
+++ b/debezium-platform-conductor/src/test/java/io/debezium/platform/environment/connection/PulsarConnectionValidatorIT.java
@@ -15,10 +15,10 @@ import java.util.concurrent.TimeUnit;
 
 import jakarta.inject.Inject;
 
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.pulsar.PulsarContainer;
-import org.testcontainers.shaded.org.awaitility.Awaitility;
 
 import io.debezium.platform.data.dto.ConnectionValidationResult;
 import io.debezium.platform.data.model.ConnectionEntity;

--- a/debezium-platform-conductor/src/test/java/io/debezium/platform/environment/connection/PulsarConnectionValidatorJwtAuthIT.java
+++ b/debezium-platform-conductor/src/test/java/io/debezium/platform/environment/connection/PulsarConnectionValidatorJwtAuthIT.java
@@ -17,11 +17,11 @@ import java.util.concurrent.TimeUnit;
 
 import jakarta.inject.Inject;
 
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.containers.Container;
 import org.testcontainers.pulsar.PulsarContainer;
-import org.testcontainers.shaded.org.awaitility.Awaitility;
 
 import io.debezium.platform.data.dto.ConnectionValidationResult;
 import io.debezium.platform.data.model.ConnectionEntity;

--- a/debezium-platform-conductor/src/test/java/io/debezium/platform/environment/connection/PulsarConnectionValidatorOAuth2IT.java
+++ b/debezium-platform-conductor/src/test/java/io/debezium/platform/environment/connection/PulsarConnectionValidatorOAuth2IT.java
@@ -17,10 +17,10 @@ import java.util.concurrent.TimeUnit;
 
 import jakarta.inject.Inject;
 
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.pulsar.PulsarContainer;
-import org.testcontainers.shaded.org.awaitility.Awaitility;
 
 import io.debezium.platform.data.dto.ConnectionValidationResult;
 import io.debezium.platform.data.model.ConnectionEntity;

--- a/debezium-platform-conductor/src/test/java/io/debezium/platform/environment/connection/RedisConnectionValidatorAuthIT.java
+++ b/debezium-platform-conductor/src/test/java/io/debezium/platform/environment/connection/RedisConnectionValidatorAuthIT.java
@@ -14,10 +14,10 @@ import java.util.Map;
 
 import jakarta.inject.Inject;
 
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.shaded.org.awaitility.Awaitility;
 
 import io.debezium.platform.data.dto.ConnectionValidationResult;
 import io.debezium.platform.data.model.ConnectionEntity;

--- a/debezium-platform-conductor/src/test/java/io/debezium/platform/environment/connection/RedisConnectionValidatorIT.java
+++ b/debezium-platform-conductor/src/test/java/io/debezium/platform/environment/connection/RedisConnectionValidatorIT.java
@@ -14,10 +14,10 @@ import java.util.Map;
 
 import jakarta.inject.Inject;
 
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.shaded.org.awaitility.Awaitility;
 
 import io.debezium.platform.data.dto.ConnectionValidationResult;
 import io.debezium.platform.data.model.ConnectionEntity;

--- a/debezium-platform-conductor/src/test/java/io/debezium/platform/environment/database/db/MongoDbTestResource.java
+++ b/debezium-platform-conductor/src/test/java/io/debezium/platform/environment/database/db/MongoDbTestResource.java
@@ -8,9 +8,9 @@ package io.debezium.platform.environment.database.db;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
+import org.awaitility.Awaitility;
 import org.bson.Document;
 import org.testcontainers.mongodb.MongoDBContainer;
-import org.testcontainers.shaded.org.awaitility.Awaitility;
 import org.testcontainers.utility.DockerImageName;
 
 import com.mongodb.client.MongoClients;


### PR DESCRIPTION
<!-- Make sure all your commits are signed before submitting your pull request -->
<!-- Run `git commit -s` to sign off your commits to satisfy the DCO check -->
<!-- Ensure your commit messages start with your GitHub issue, e.g., debezium/dbz#<issue_number> -->
Fixes debezium/dbz#2027

## Description
This pull request introduces a heartbeat mechanism to the Debezium platform conductor to ensure the replication slot's confirmed_flush_lsn advances even when there are no outbox events. It adds configuration, database schema, and logic for periodic heartbeat actions, improves logging, and adds integration tests to verify the heartbeat's effect. 


## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [X] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [X] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [X] One feature/change per PR unless tightly coupled
- [X] Do a rebase on upstream `main`
