### PR TITLE
debezium/dbz#2112 Null check on predicates

### DIFF
--- a/debezium-platform-conductor/src/main/java/io/debezium/platform/environment/operator/PipelineMapper.java
+++ b/debezium-platform-conductor/src/main/java/io/debezium/platform/environment/operator/PipelineMapper.java
@@ -106,6 +106,7 @@ public class PipelineMapper {
                 .toList();
 
         Map<String, Predicate> predicates = pipeline.getTransforms().stream()
+                .filter(this::hasPredicate)
                 .collect(Collectors.toMap(
                         this::getPredicateName,
                         this::buildPredicate));
@@ -301,13 +302,20 @@ public class PipelineMapper {
         var transformConfig = new ConfigProperties();
         transformConfig.setAllProps(transform.getConfig());
 
-        return new TransformationBuilder()
+        var builder = new TransformationBuilder()
                 .withType(transform.getType())
-                .withConfig(transformConfig)
-                .withPredicate(getPredicateName(transform))
-                .withNegate(transform.getPredicate().isNegate())
-                .build();
+                .withConfig(transformConfig);
 
+        if (hasPredicate(transform)) {
+            builder.withPredicate(getPredicateName(transform))
+                    .withNegate(transform.getPredicate().isNegate());
+        }
+
+        return builder.build();
+    }
+
+    private boolean hasPredicate(Transform transform) {
+        return transform.getPredicate() != null && transform.getPredicate().getType() != null;
     }
 
     private String getPredicateName(Transform transform) {

--- a/debezium-platform-conductor/src/test/java/io/debezium/platform/environment/connection/JdbcConnectionValidatorIT.java
+++ b/debezium-platform-conductor/src/test/java/io/debezium/platform/environment/connection/JdbcConnectionValidatorIT.java
@@ -14,10 +14,10 @@ import java.util.Map;
 
 import jakarta.inject.Inject;
 
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.containers.PostgreSQLContainer;
-import org.testcontainers.shaded.org.awaitility.Awaitility;
 
 import io.debezium.platform.data.dto.ConnectionValidationResult;
 import io.debezium.platform.data.model.ConnectionEntity;

--- a/debezium-platform-conductor/src/test/java/io/debezium/platform/environment/operator/PipelineMapperTest.java
+++ b/debezium-platform-conductor/src/test/java/io/debezium/platform/environment/operator/PipelineMapperTest.java
@@ -13,6 +13,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -25,11 +26,13 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 
+import io.debezium.doc.FixFor;
 import io.debezium.operator.api.model.runtime.metrics.Metrics;
 import io.debezium.operator.api.model.runtime.metrics.MetricsBuilder;
 import io.debezium.platform.config.PipelineConfigGroup;
 import io.debezium.platform.data.model.ConnectionEntity;
 import io.debezium.platform.domain.views.Connection;
+import io.debezium.platform.domain.views.Transform;
 import io.debezium.platform.domain.views.flat.DestinationFlat;
 import io.debezium.platform.domain.views.flat.PipelineFlat;
 import io.debezium.platform.domain.views.flat.SourceFlat;
@@ -186,6 +189,33 @@ public class PipelineMapperTest {
         var otel = result.getSpec().getRuntime().getMetrics().getOpenTelemetry();
         assertThat(otel.isEnabled()).isTrue();
         assertThat(otel.getCollector().getEndpoint()).isNull();
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2112")
+    public void testMapper_ShouldHandleTransformWithEmptyPredicate() {
+        var pipeline = mockPipelineWithSource(ConnectionEntity.Type.POSTGRESQL, Map.of(
+                DATABASE, "customers",
+                USERNAME, "sa"));
+
+        var predicate = mock(io.debezium.platform.domain.views.Predicate.class);
+        when(predicate.getType()).thenReturn(null);
+        when(predicate.getConfig()).thenReturn(null);
+        when(predicate.isNegate()).thenReturn(false);
+
+        var transform = mock(Transform.class);
+        when(transform.getId()).thenReturn(1L);
+        when(transform.getType()).thenReturn("io.debezium.transforms.ExtractNewRecordState");
+        when(transform.getConfig()).thenReturn(Map.of("delete.handling.mode", "none"));
+        when(transform.getPredicate()).thenReturn(predicate);
+        when(pipeline.getTransforms()).thenReturn(List.of(transform));
+
+        var result = pipelineMapper.map(pipeline);
+
+        assertThat(result.getSpec().getTransforms()).hasSize(1);
+        assertThat(result.getSpec().getTransforms().get(0).getType())
+                .isEqualTo("io.debezium.transforms.ExtractNewRecordState");
+        assertThat(result.getSpec().getPredicates()).isEmpty();
     }
 
     private PipelineMapper createMapper() {


### PR DESCRIPTION
<!-- Make sure all your commits are signed before submitting your pull request -->
<!-- Run `git commit -s` to sign off your commits to satisfy the DCO check -->
<!-- Ensure your commit messages start with your GitHub issue, e.g., debezium/dbz#<issue_number> -->
Fixes debezium/dbz#2112

## Description
This pull request improves the handling of pipeline transforms with empty or missing predicates in the `PipelineMapper`. The main change ensures that transforms with empty predicates are not incorrectly processed as having valid predicates, which could lead to invalid configuration. Additionally, a targeted unit test is added to verify this behavior.


## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [X] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [X] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [X] One feature/change per PR unless tightly coupled
- [X] Do a rebase on upstream `main`
