### PR TITLE
debezium/dbz#2123 Outbox watcher engine stops processing after a consumer error, causing loop in conductor  

### DIFF
--- a/debezium-platform-conductor/src/main/java/io/debezium/platform/environment/watcher/config/WatcherConfigGroup.java
+++ b/debezium-platform-conductor/src/main/java/io/debezium/platform/environment/watcher/config/WatcherConfigGroup.java
@@ -11,6 +11,7 @@ import io.debezium.platform.config.OffsetConfigGroup;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
 import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithDefault;
 import io.smallrye.config.WithName;
 
 @ConfigMapping(prefix = "conductor.watcher")
@@ -25,10 +26,20 @@ public interface WatcherConfigGroup {
 
     HeartbeatConfig heartbeat();
 
+    RetryConfig retry();
+
     interface HeartbeatConfig {
 
         @WithName("interval-ms")
         int intervalMs();
+
+    }
+
+    interface RetryConfig {
+
+        @WithDefault("3")
+        @WithName("max-retries")
+        int maxRetries();
 
     }
 

--- a/debezium-platform-conductor/src/main/java/io/debezium/platform/environment/watcher/consumers/OutboxParentEventConsumer.java
+++ b/debezium-platform-conductor/src/main/java/io/debezium/platform/environment/watcher/consumers/OutboxParentEventConsumer.java
@@ -17,6 +17,7 @@ import org.slf4j.LoggerFactory;
 
 import io.debezium.engine.ChangeEvent;
 import io.debezium.platform.environment.watcher.config.OutboxConfigGroup;
+import io.fabric8.kubernetes.client.KubernetesClientException;
 
 /**
  * Top level consumer of outbox events. Parent consumer will extract
@@ -31,6 +32,7 @@ import io.debezium.platform.environment.watcher.config.OutboxConfigGroup;
 public final class OutboxParentEventConsumer implements Consumer<ChangeEvent<SourceRecord, SourceRecord>> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(OutboxParentEventConsumer.class);
+    private static final int MAX_RETRIES = 3;
 
     private final OutboxConfigGroup outbox;
     private final Instance<EnvironmentEventConsumer<?>> eventConsumers;
@@ -48,14 +50,76 @@ public final class OutboxParentEventConsumer implements Consumer<ChangeEvent<Sou
             return;
         }
 
-        var aggregateType = value.getString(outbox.aggregateColumn());
-        var aggregateId = value.getString(outbox.aggregateIdColumn());
-        var eventType = value.getString(outbox.typeColumn());
-        var payload = value.getString("payload");
+        var context = EventContext.from(value, outbox);
 
-        LOGGER.debug("Consumed {} event for {} (#{}) with payload {}", eventType, aggregateType, aggregateId, payload);
+        LOGGER.debug("Consumed {} event for {} (#{}) with payload {}",
+                context.eventType(), context.aggregateType(), context.aggregateId(), context.payload());
 
-        eventConsumers.forEach(consumer -> consumer.consume(
-                aggregateType, eventType, Long.valueOf(aggregateId), payload));
+        eventConsumers.forEach(consumer -> consumeWithRetry(consumer, context));
+    }
+
+    private void consumeWithRetry(EnvironmentEventConsumer<?> consumer, EventContext context) {
+
+        for (int attempt = 1; attempt <= MAX_RETRIES + 1; attempt++) {
+            try {
+                consumer.consume(context.aggregateType(), context.eventType(),
+                        Long.valueOf(context.aggregateId()), context.payload());
+                return;
+            }
+            catch (Exception e) {
+                if (isRetriable(e) && attempt <= MAX_RETRIES) {
+                    var delay = backoffDelay(attempt);
+                    LOGGER.warn("Retriable error processing {} event for aggregate {} (#{}),"
+                            + " attempt {}/{}, retrying in {}ms",
+                            context.eventType(), context.aggregateType(), context.aggregateId(),
+                            attempt, MAX_RETRIES, delay, e);
+                    if (!sleep(delay)) {
+                        return;
+                    }
+                }
+                else {
+                    LOGGER.error("Failed to process {} event for aggregate {} (#{}){}. Skipping event.",
+                            context.eventType(), context.aggregateType(), context.aggregateId(),
+                            attempt > 1 ? " after %d retries".formatted(attempt - 1) : "",
+                            e);
+                    return;
+                }
+            }
+        }
+    }
+
+    private long backoffDelay(int attempt) {
+        return (long) Math.pow(2, attempt - 1) * 1000;
+    }
+
+    private boolean sleep(long millis) {
+        try {
+            Thread.sleep(millis);
+            return true;
+        }
+        catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return false;
+        }
+    }
+
+    private boolean isRetriable(Throwable throwable) {
+        for (var current = throwable; current != null; current = current.getCause()) {
+            if (current instanceof KubernetesClientException) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private record EventContext(String aggregateType, String aggregateId, String eventType, String payload) {
+
+        static EventContext from(Struct value, OutboxConfigGroup outbox) {
+            return new EventContext(
+                    value.getString(outbox.aggregateColumn()),
+                    value.getString(outbox.aggregateIdColumn()),
+                    value.getString(outbox.typeColumn()),
+                    value.getString("payload"));
+        }
     }
 }

--- a/debezium-platform-conductor/src/main/java/io/debezium/platform/environment/watcher/consumers/OutboxParentEventConsumer.java
+++ b/debezium-platform-conductor/src/main/java/io/debezium/platform/environment/watcher/consumers/OutboxParentEventConsumer.java
@@ -17,6 +17,7 @@ import org.slf4j.LoggerFactory;
 
 import io.debezium.engine.ChangeEvent;
 import io.debezium.platform.environment.watcher.config.OutboxConfigGroup;
+import io.debezium.platform.environment.watcher.config.WatcherConfigGroup;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 
 /**
@@ -32,14 +33,16 @@ import io.fabric8.kubernetes.client.KubernetesClientException;
 public final class OutboxParentEventConsumer implements Consumer<ChangeEvent<SourceRecord, SourceRecord>> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(OutboxParentEventConsumer.class);
-    private static final int MAX_RETRIES = 3;
 
     private final OutboxConfigGroup outbox;
     private final Instance<EnvironmentEventConsumer<?>> eventConsumers;
+    private final int maxRetries;
 
-    public OutboxParentEventConsumer(OutboxConfigGroup outbox, Instance<EnvironmentEventConsumer<?>> eventConsumers) {
+    public OutboxParentEventConsumer(OutboxConfigGroup outbox, WatcherConfigGroup watcherConfig,
+                                     Instance<EnvironmentEventConsumer<?>> eventConsumers) {
         this.outbox = outbox;
         this.eventConsumers = eventConsumers;
+        this.maxRetries = watcherConfig.retry().maxRetries();
     }
 
     @Override
@@ -60,19 +63,19 @@ public final class OutboxParentEventConsumer implements Consumer<ChangeEvent<Sou
 
     private void consumeWithRetry(EnvironmentEventConsumer<?> consumer, EventContext context) {
 
-        for (int attempt = 1; attempt <= MAX_RETRIES + 1; attempt++) {
+        for (int attempt = 1; attempt <= maxRetries + 1; attempt++) {
             try {
                 consumer.consume(context.aggregateType(), context.eventType(),
                         Long.valueOf(context.aggregateId()), context.payload());
                 return;
             }
             catch (Exception e) {
-                if (isRetriable(e) && attempt <= MAX_RETRIES) {
+                if (isRetriable(e) && attempt <= maxRetries) {
                     var delay = backoffDelay(attempt);
                     LOGGER.warn("Retriable error processing {} event for aggregate {} (#{}),"
                             + " attempt {}/{}, retrying in {}ms",
                             context.eventType(), context.aggregateType(), context.aggregateId(),
-                            attempt, MAX_RETRIES, delay, e);
+                            attempt, maxRetries, delay, e);
                     if (!sleep(delay)) {
                         return;
                     }

--- a/debezium-platform-conductor/src/main/resources/application.yml
+++ b/debezium-platform-conductor/src/main/resources/application.yml
@@ -7,6 +7,8 @@ conductor:
     enabled: true
     heartbeat:
       interval-ms: 300000
+    retry:
+      max-retries: 3
     offset:
       storage:
         type: org.apache.kafka.connect.storage.FileOffsetBackingStore

--- a/debezium-platform-conductor/src/test/java/io/debezium/platform/environment/watcher/consumers/OutboxEventConsumerResilienceIT.java
+++ b/debezium-platform-conductor/src/test/java/io/debezium/platform/environment/watcher/consumers/OutboxEventConsumerResilienceIT.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.platform.environment.watcher.consumers;
+
+import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+
+import org.awaitility.Awaitility;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+import io.debezium.doc.FixFor;
+import io.debezium.operator.api.model.DebeziumServer;
+import io.debezium.platform.OutboxTestProfile;
+import io.debezium.platform.environment.operator.actions.DebeziumKubernetesAdapter;
+import io.debezium.platform.util.TestDatasourceHelper;
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.quarkus.test.InjectMock;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+
+@QuarkusTest
+@TestProfile(OutboxTestProfile.class)
+@EnableKubernetesMockClient(crud = true)
+class OutboxEventConsumerResilienceIT {
+
+    @InjectMock
+    DebeziumKubernetesAdapter k8sAdapter;
+
+    @ConfigProperty(name = "quarkus.datasource.jdbc.url")
+    String datasourceUrl;
+
+    Long sourceId;
+    Long destinationId;
+    String resourceSuffix;
+
+    @BeforeEach
+    void setUp() {
+        Mockito.reset(k8sAdapter);
+        resourceSuffix = String.valueOf(System.nanoTime());
+
+        TestDatasourceHelper dbHelper = TestDatasourceHelper.parsePostgresJdbcUrl(datasourceUrl);
+
+        Long sourceConnectionId = createResource("api/connections", """
+                {
+                       "name": "postgres-connection-%s",
+                       "type": "POSTGRESQL",
+                       "config": {
+                         "hostname": "postgresql",
+                         "port": %s,
+                         "username": "debezium",
+                         "password": "debezium",
+                         "database": "debezium"
+                       }
+                     }
+                  }""".formatted(resourceSuffix, dbHelper.getPort()));
+
+        Long destinationConnectionId = createResource("api/connections", """
+                {
+                     "name": "kafka-connection-%s",
+                     "type": "KAFKA",
+                     "config": {
+                       "bootstrap.servers": "dbz-kafka-kafka-bootstrap.debezium-platform:9092"
+                     }
+                   }""".formatted(resourceSuffix));
+
+        sourceId = createResource("api/sources", """
+                {
+                    "name": "test-source-%s",
+                    "description": "Test source",
+                    "type": "io.debezium.connector.postgresql.PostgresConnector",
+                    "schema": "dummy",
+                    "vaults": [],
+                    "connection": {
+                        "id": %s
+                    },
+                    "config": {
+                      "topic.prefix": "inventory",
+                      "schema.include.list": "inventory"
+                    }
+                  }""".formatted(resourceSuffix, sourceConnectionId));
+
+        destinationId = createResource("api/destinations", """
+                 {
+                  "name": "test-destination-%s",
+                  "type": "kafka",
+                  "description": "Test destination",
+                  "schema": "dummy",
+                  "vaults": [],
+                   "connection": {
+                        "id": %s
+                    },
+                  "config": {
+                    "producer.key.serializer": "org.apache.kafka.common.serialization.StringSerializer",
+                    "producer.value.serializer": "org.apache.kafka.common.serialization.StringSerializer"
+                  }
+                }""".formatted(resourceSuffix, destinationConnectionId));
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2123")
+    @DisplayName("Engine should continue processing outbox events after a non-retriable deployment error")
+    void engineShouldContinueProcessingAfterNonRetriableError() {
+
+        var captor = ArgumentCaptor.forClass(DebeziumServer.class);
+        var failingPipelineName = "pipeline-failing-" + resourceSuffix;
+        var succeedingPipelineName = "pipeline-succeeding-" + resourceSuffix;
+
+        doAnswer(invocation -> {
+            DebeziumServer ds = invocation.getArgument(0);
+            if (ds.getMetadata().getName().equals(failingPipelineName)) {
+                throw new NullPointerException("Cannot invoke \"java.util.Map.size()\" because \"m\" is null");
+            }
+            return null;
+        }).when(k8sAdapter).deployPipeline(any());
+
+        createResource("api/pipelines", """
+                {
+                   "name": "%s",
+                   "description": "This pipeline will fail during deployment",
+                   "source": {
+                     "id": %s,
+                     "name": "test-source-%s"
+                   },
+                   "destination": {
+                     "id": %s,
+                     "name": "test-destination-%s"
+                   },
+                   "transforms": [],
+                   "logLevel": "INFO",
+                   "logLevels": {}
+                 }""".formatted(failingPipelineName, sourceId, resourceSuffix, destinationId, resourceSuffix));
+
+        createResource("api/pipelines", """
+                {
+                   "name": "%s",
+                   "description": "This pipeline should still be deployed",
+                   "source": {
+                     "id": %s,
+                     "name": "test-source-%s"
+                   },
+                   "destination": {
+                     "id": %s,
+                     "name": "test-destination-%s"
+                   },
+                   "transforms": [],
+                   "logLevel": "INFO",
+                   "logLevels": {}
+                 }""".formatted(succeedingPipelineName, sourceId, resourceSuffix, destinationId, resourceSuffix));
+
+        Awaitility.await()
+                .atMost(Duration.of(120, ChronoUnit.SECONDS))
+                .pollDelay(Duration.of(100, ChronoUnit.MILLIS))
+                .pollInterval(Duration.of(500, ChronoUnit.MILLIS))
+                .untilAsserted(() -> {
+                    Mockito.verify(k8sAdapter, Mockito.atLeast(2)).deployPipeline(captor.capture());
+                    assertThat(captor.getAllValues().stream()
+                            .anyMatch(ds -> ds.getMetadata().getName().equals(succeedingPipelineName)))
+                            .as("Second pipeline should have been deployed despite the first one failing")
+                            .isTrue();
+                });
+    }
+
+    private static Long createResource(String path, String body) {
+        Number id = given()
+                .header("Content-Type", "application/json")
+                .body(body).when().post(path)
+                .then()
+                .statusCode(201)
+                .extract()
+                .path("id");
+
+        return id.longValue();
+    }
+}


### PR DESCRIPTION
<!-- Make sure all your commits are signed before submitting your pull request -->
<!-- Run `git commit -s` to sign off your commits to satisfy the DCO check -->
<!-- Ensure your commit messages start with your GitHub issue, e.g., debezium/dbz#<issue_number> -->
Fixes debezium/dbz#2123

## Description
This pull request introduces improved error handling and resilience to the `OutboxParentEventConsumer`, ensuring that transient errors (such as Kubernetes client exceptions) are retried with exponential backoff, while non-retriable errors do not block processing of subsequent events. Additionally, a new integration test verifies that the event consumer continues processing after encountering non-retriable errors.


## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [X] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [X] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [X] One feature/change per PR unless tightly coupled
- [X] Do a rebase on upstream `main`
