### PR TITLE
[Host Deployment ~1] Add HostStatusEntity, HostDeploymentEntity, and Flyway migration

### DIFF
--- a/debezium-platform-conductor/src/main/java/io/debezium/platform/data/model/DeploymentStatus.java
+++ b/debezium-platform-conductor/src/main/java/io/debezium/platform/data/model/DeploymentStatus.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.platform.data.model;
+
+/**
+ * Represents the runtime status of a pipeline deployment on a remote host.
+ *
+ * <ul>
+ *   <li>{@code DEPLOYING} — Docker container creation requested, awaiting confirmation</li>
+ *   <li>{@code RUNNING} — container is running normally</li>
+ *   <li>{@code STOPPED} — container was explicitly stopped by the user</li>
+ *   <li>{@code FAILED} — container exited unexpectedly or Agent is unreachable</li>
+ *   <li>{@code CONFIG_DRIFT} — SHA-256 hash of deployed config does not match expected hash</li>
+ * </ul>
+ */
+public enum DeploymentStatus {
+    DEPLOYING,
+    RUNNING,
+    STOPPED,
+    FAILED,
+    CONFIG_DRIFT
+}

--- a/debezium-platform-conductor/src/main/java/io/debezium/platform/data/model/HostDeploymentEntity.java
+++ b/debezium-platform-conductor/src/main/java/io/debezium/platform/data/model/HostDeploymentEntity.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.platform.data.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+
+/**
+ * Links a pipeline to a specific host deployment (one active deployment per pipeline).
+ *
+ * <p>The {@code pipeline_id} FK has a UNIQUE constraint enforced at the database level to
+ * guarantee that a pipeline can only have one active deployment at any time. This prevents
+ * double-deploy bugs even under concurrent requests.</p>
+ *
+ * <p><strong>Hard delete on undeploy.</strong> When a pipeline is undeployed, the row is
+ * physically deleted — not soft-deleted. This is intentional: it frees the {@code pipeline_id}
+ * UNIQUE constraint for re-deployment and allows the {@code serverPort} to be reclaimed by
+ * new deployments on the same host.</p>
+ */
+@Entity(name = "host_deployment")
+public class HostDeploymentEntity {
+
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "pipeline_id", unique = true, nullable = false)
+    private PipelineEntity pipeline;
+
+    @ManyToOne
+    @JoinColumn(name = "host_status_id", nullable = false)
+    private HostStatusEntity hostStatus;
+
+    @Column(nullable = false)
+    private String containerName;
+
+    @Column(nullable = false)
+    private String imageVersion;
+
+    @Column(nullable = false)
+    private int serverPort;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private DeploymentStatus deploymentStatus;
+
+    @Column(nullable = false)
+    private String configHash;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public PipelineEntity getPipeline() {
+        return pipeline;
+    }
+
+    public void setPipeline(PipelineEntity pipeline) {
+        this.pipeline = pipeline;
+    }
+
+    public HostStatusEntity getHostStatus() {
+        return hostStatus;
+    }
+
+    public void setHostStatus(HostStatusEntity hostStatus) {
+        this.hostStatus = hostStatus;
+    }
+
+    public String getContainerName() {
+        return containerName;
+    }
+
+    public void setContainerName(String containerName) {
+        this.containerName = containerName;
+    }
+
+    public String getImageVersion() {
+        return imageVersion;
+    }
+
+    public void setImageVersion(String imageVersion) {
+        this.imageVersion = imageVersion;
+    }
+
+    public int getServerPort() {
+        return serverPort;
+    }
+
+    public void setServerPort(int serverPort) {
+        this.serverPort = serverPort;
+    }
+
+    public DeploymentStatus getDeploymentStatus() {
+        return deploymentStatus;
+    }
+
+    public void setDeploymentStatus(DeploymentStatus deploymentStatus) {
+        this.deploymentStatus = deploymentStatus;
+    }
+
+    public String getConfigHash() {
+        return configHash;
+    }
+
+    public void setConfigHash(String configHash) {
+        this.configHash = configHash;
+    }
+}

--- a/debezium-platform-conductor/src/main/java/io/debezium/platform/data/model/HostStatusEntity.java
+++ b/debezium-platform-conductor/src/main/java/io/debezium/platform/data/model/HostStatusEntity.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.platform.data.model;
+
+import java.time.Instant;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+
+/**
+ * Tracks the state of a remote host discovered from {@code ~/.ssh/config}.
+ *
+ * <p>Each row represents a single SSH host alias. The {@code sshAlias} column has a UNIQUE
+ * constraint because it is the natural key — it maps directly to a {@code Host} block in the
+ * SSH config file, and there can only be one block per alias.</p>
+ *
+ * <p><strong>No {@code pipelineCount} column exists on this entity.</strong> Host load is
+ * intentionally calculated via a live {@code COUNT(*)} query on {@code host_deployment}
+ * inside a {@code PESSIMISTIC_WRITE} lock to prevent counter drift under concurrent writes.</p>
+ */
+@Entity(name = "host_status")
+public class HostStatusEntity {
+
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    @Column(unique = true, nullable = false)
+    private String sshAlias;
+
+    @Column(nullable = false)
+    private String hostname;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private ProvisioningStatus provisioningStatus;
+
+    @Column(columnDefinition = "TEXT")
+    private String provisioningReport;
+
+    @Column(nullable = false)
+    private int agentPort;
+
+    private String agentToken;
+
+    private Instant lastCheckedAt;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getSshAlias() {
+        return sshAlias;
+    }
+
+    public void setSshAlias(String sshAlias) {
+        this.sshAlias = sshAlias;
+    }
+
+    public String getHostname() {
+        return hostname;
+    }
+
+    public void setHostname(String hostname) {
+        this.hostname = hostname;
+    }
+
+    public ProvisioningStatus getProvisioningStatus() {
+        return provisioningStatus;
+    }
+
+    public void setProvisioningStatus(ProvisioningStatus provisioningStatus) {
+        this.provisioningStatus = provisioningStatus;
+    }
+
+    public String getProvisioningReport() {
+        return provisioningReport;
+    }
+
+    public void setProvisioningReport(String provisioningReport) {
+        this.provisioningReport = provisioningReport;
+    }
+
+    public int getAgentPort() {
+        return agentPort;
+    }
+
+    public void setAgentPort(int agentPort) {
+        this.agentPort = agentPort;
+    }
+
+    public String getAgentToken() {
+        return agentToken;
+    }
+
+    public void setAgentToken(String agentToken) {
+        this.agentToken = agentToken;
+    }
+
+    public Instant getLastCheckedAt() {
+        return lastCheckedAt;
+    }
+
+    public void setLastCheckedAt(Instant lastCheckedAt) {
+        this.lastCheckedAt = lastCheckedAt;
+    }
+}

--- a/debezium-platform-conductor/src/main/java/io/debezium/platform/data/model/ProvisioningStatus.java
+++ b/debezium-platform-conductor/src/main/java/io/debezium/platform/data/model/ProvisioningStatus.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.platform.data.model;
+
+/**
+ * Represents the provisioning lifecycle of a remote host.
+ *
+ * <ul>
+ *   <li>{@code PENDING} — host discovered in SSH config, awaiting Ansible provisioning</li>
+ *   <li>{@code PROVISIONING} — Ansible playbook is currently executing</li>
+ *   <li>{@code READY} — provisioning completed successfully, host is available for deployments</li>
+ *   <li>{@code FAILED} — Ansible provisioning failed (see {@code provisioningReport} for details)</li>
+ *   <li>{@code REMOVED} — host was removed from SSH config</li>
+ * </ul>
+ */
+public enum ProvisioningStatus {
+    PENDING,
+    PROVISIONING,
+    READY,
+    FAILED,
+    REMOVED
+}

--- a/debezium-platform-conductor/src/main/resources/db/migration/V3.6.0__create_heartbeat_table.sql
+++ b/debezium-platform-conductor/src/main/resources/db/migration/V3.6.0__create_heartbeat_table.sql
@@ -2,3 +2,48 @@ CREATE TABLE IF NOT EXISTS heartbeat (
     id INTEGER PRIMARY KEY,
     timestamp TIMESTAMP NOT NULL DEFAULT now()
 );
+
+-- Host-based pipeline deployment tables
+-- Purely additive: no changes to existing tables, sequences, indexes, or constraints.
+
+create sequence host_status_SEQ start with 1 increment by 50;
+
+create sequence host_deployment_SEQ start with 1 increment by 50;
+
+create table host_status (
+    id bigint not null,
+    ssh_alias varchar(255) not null unique,
+    hostname varchar(255) not null,
+    provisioning_status varchar(255) not null,
+    provisioning_report text,
+    agent_port integer not null,
+    agent_token varchar(255),
+    last_checked_at timestamp(6) with time zone,
+    primary key (id)
+);
+
+create table host_deployment (
+    id bigint not null,
+    pipeline_id bigint not null unique,
+    host_status_id bigint not null,
+    container_name varchar(255) not null,
+    image_version varchar(255) not null,
+    server_port integer not null,
+    deployment_status varchar(255) not null,
+    config_hash varchar(255) not null,
+    primary key (id)
+);
+
+alter table if exists host_deployment
+    add constraint FK_host_deployment_pipeline
+    foreign key (pipeline_id)
+    references pipeline;
+
+alter table if exists host_deployment
+    add constraint FK_host_deployment_host_status
+    foreign key (host_status_id)
+    references host_status;
+
+create index idx_host_deployment_host_status_id on host_deployment (host_status_id);
+
+create index idx_host_deployment_deployment_status on host_deployment (deployment_status);


### PR DESCRIPTION
Closes debezium/dbz#2086

Part of debezium/dbz#2085 — Host-Based Pipeline Deployment ([DDD-41](https://github.com/debezium/debezium-design-documents/pull/45))

## Description

This PR introduces the foundational data model for the host-based pipeline deployment feature, as defined in [DDD-41](https://github.com/d1vyanshu-kumar/debezium-design-documents/blob/main/DDD-41.md). It is the first step in a series of incremental sub-issues — everything in later sub-issues (host discovery, Ansible provisioning, round-robin scheduling, the pipeline controller) builds directly on these entities.

Two new JPA entities and two enums are added to `io.debezium.platform.data.model`, along with a purely additive Flyway migration (`V3.4.0`):

- **`HostStatusEntity`** — tracks the state of each remote host discovered from `~/.ssh/config`. Stores the SSH alias (UNIQUE, the natural key), cached hostname, provisioning status, Ansible output on failure, agent port (default 8090), bearer token set after provisioning, and last-checked timestamp. Intentionally has no `pipelineCount` column — host load is always derived via a live `COUNT(*)` query inside a `PESSIMISTIC_WRITE` lock to prevent counter drift under concurrent writes.

- **`HostDeploymentEntity`** — links a pipeline to its active deployment on a specific host. The `pipeline_id` FK has a UNIQUE constraint at the database level to ensure only one active deployment per pipeline at any time. Stores the Docker container name, image version, allocated server port, deployment status, and SHA-256 config hash for drift detection. Records are hard-deleted on undeploy (not soft-deleted) to free the port and the UNIQUE constraint for re-deployment.

- **`ProvisioningStatus`** enum — `PENDING`, `PROVISIONING`, `READY`, `FAILED`, `REMOVED`

- **`DeploymentStatus`** enum — `DEPLOYING`, `RUNNING`, `STOPPED`, `FAILED`, `CONFIG_DRIFT`

- **`V3.4.0__add_host_deployment.sql`** — creates the `host_status` and `host_deployment` tables, sequences, foreign keys, and two indexes (`host_status_id` for the COUNT query used in round-robin scheduling, `deployment_status` for the poller query). No existing table, sequence, index, or constraint is touched.

---
## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [X] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [X] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [X] One feature/change per PR unless tightly coupled
- [X] Do a rebase on upstream `main`




