### PR TITLE
debezium/dbz#2141 Exclude jersey libs to avoid weird issue with RESTeasy

### DIFF
--- a/debezium-platform-conductor/pom.xml
+++ b/debezium-platform-conductor/pom.xml
@@ -323,6 +323,16 @@
         <dependency>
             <groupId>io.debezium</groupId>
             <artifactId>debezium-embedded</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.glassfish.jersey.containers</groupId>
+                    <artifactId>jersey-container-servlet</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.glassfish.jersey.inject</groupId>
+                    <artifactId>jersey-hk2</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- Storages  -->

--- a/debezium-platform-conductor/src/main/java/io/debezium/platform/domain/MonitoringService.java
+++ b/debezium-platform-conductor/src/main/java/io/debezium/platform/domain/MonitoringService.java
@@ -54,7 +54,7 @@ public class MonitoringService {
                 .findFirst()
                 .orElseThrow(() -> new NotFoundException("Panel not found: " + panelId));
 
-        String query = encodePromQLBraces(panelConfig.query().replace(PIPELINE_ID_PLACEHOLDER, pipelineId));
+        String query = panelConfig.query().replace(PIPELINE_ID_PLACEHOLDER, pipelineId);
 
         if (Strings.isNullOrBlank(step)) {
             step = panelConfig.visualization().suggestedStep();
@@ -76,11 +76,6 @@ public class MonitoringService {
                 new PanelQueryResponse.TimeRange(start.toString(), end.toString(), step),
                 series,
                 new PanelQueryResponse.Metadata(queryDuration));
-    }
-
-    // Curly braces must be pre-encoded to avoid JAX-RS interpreting them as URI template variables
-    private static String encodePromQLBraces(String query) {
-        return query.replace("{", "%7B").replace("}", "%7D");
     }
 
     private List<PanelQueryResponse.TimeSeries> transformResponse(PrometheusQueryRangeResponse response) {

--- a/debezium-platform-conductor/src/test/java/io/debezium/platform/domain/MonitoringServiceTest.java
+++ b/debezium-platform-conductor/src/test/java/io/debezium/platform/domain/MonitoringServiceTest.java
@@ -86,7 +86,7 @@ class MonitoringServiceTest {
                 "event-count", "my-pipeline", Instant.parse("2026-04-23T10:00:00Z"), Instant.parse("2026-04-23T11:00:00Z"), "1m");
 
         verify(prometheusClient).queryRange(
-                eq("rate(debezium_event_count_total%7Bservice_name=\"my-pipeline\"%7D[5m])"),
+                eq("rate(debezium_event_count_total{service_name=\"my-pipeline\"}[5m])"),
                 eq("2026-04-23T10:00:00Z"),
                 eq("2026-04-23T11:00:00Z"),
                 eq("1m"));

--- a/debezium-platform-conductor/src/test/java/io/debezium/platform/environment/monitoring/PrometheusTestResource.java
+++ b/debezium-platform-conductor/src/test/java/io/debezium/platform/environment/monitoring/PrometheusTestResource.java
@@ -41,7 +41,7 @@ public class PrometheusTestResource implements QuarkusTestResourceLifecycleManag
         String config = DebeziumMetricsEndpoint.prometheusConfig(
                 "host.testcontainers.internal", metricsPort, "1s");
 
-        prometheus = new GenericContainer<>(DockerImageName.parse("prom/prometheus:v2.53.0"))
+        prometheus = new GenericContainer<>(DockerImageName.parse("prom/prometheus:v3.12.0"))
                 .withExposedPorts(PROMETHEUS_PORT)
                 .withCopyToContainer(
                         Transferable.of(config.getBytes(StandardCharsets.UTF_8)),

--- a/debezium-platform-conductor/src/test/resources/application.properties
+++ b/debezium-platform-conductor/src/test/resources/application.properties
@@ -1,0 +1,2 @@
+quarkus.rest-client.logging.scope=request-response
+quarkus.log.category."org.jboss.resteasy.reactive.client.logging".level=DEBUG


### PR DESCRIPTION
<!-- Make sure all your commits are signed before submitting your pull request -->
<!-- Run `git commit -s` to sign off your commits to satisfy the DCO check -->
<!-- Ensure your commit messages start with your GitHub issue, e.g., debezium/dbz#<issue_number> -->
Fixes debezium/dbz#2141

## Description

### Root Cause

A non-deterministic ServiceLoader resolution of `jakarta.ws.rs.ext.RuntimeDelegate` caused two different `UriBuilder` implementations to be used depending on classpath ordering:

The conflict chain:
1. `ClientImpl.target(URI)` calls `UriBuilder.fromUri()`→ `RuntimeDelegate.getInstance().createUriBuilder()`
2. `RuntimeDelegate.getInstance()` uses `ServiceLoader`, first provider found wins
3. Three competing RuntimeDelegate providers exist on the classpath:
  - `eesteasy-reactive-common-3.34.2.jar` → RESTEasy's RuntimeDelegateImpl
  - `jersey-common-3.1.10.jar` → Jersey's RuntimeDelegateImpl
  - `jersey-server-3.1.10.jar` → Jersey's server RuntimeDelegateImpl

Jersey comes from: `debezium-embedded` → `connect-runtime (Kafka)` → `jersey-container-servlet:3.1.10` (runtime scope). 

In tests (Jersey's RuntimeDelegate wins):
- Creates `JerseyUriBuilder`
- `WebTargetImpl.queryParam()` checks instanceof `UriBuilderImpl` → false → takes generic `UriBuilder.queryParam()` path
- Pre-encoded `%7B` is preserved → Prometheus gets correct query → 200 OK
- But raw `{` would fail (treated as URI template variable)

In production (RESTEasy's RuntimeDelegate wins):
- Creates `UriBuilderImpl`
- `WebTargetImpl.queryParam()` checks instanceof `UriBuilderImpl` → true → takes `clientQueryParam()` path
- `clientQueryParam()` calls `encodeQueryParamAsIs()` which encodes `%` → `%25`
- Pre-encoded `%7B` becomes `%257B` (double-encoded) → Prometheus gets garbled query → 400 Bad Request

The `encodePromQLBraces` method was written to work around the test environment (`JerseyUriBuilder` can't handle raw {), but it broke when `UriBuilderImpl` is picked up .


## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [X] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [X] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [X] One feature/change per PR unless tightly coupled
- [X] Do a rebase on upstream `main`
