### PR TITLE
debezium/dbz#2142 Pass monitoring.prometheus.url as conductor env

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,16 @@ helm repo add prometheus-community https://prometheus-community.github.io/helm-c
 helm install kube-prometheus-stack prometheus-community/kube-prometheus-stack -n monitoring --create-namespace
 ```
 
+When monitoring is enabled, configure the Prometheus URL in your values file so the conductor can query metrics:
+
+```yaml
+monitoring:
+  otel:
+    enabled: true
+  prometheus:
+    url: "http://kube-prometheus-stack-prometheus.monitoring.svc.cluster.local:9090"
+```
+
 Create a dedicated namespace
 
 ```shell

--- a/helm/README.md
+++ b/helm/README.md
@@ -41,6 +41,15 @@ The following operators must be installed in the cluster **before** deploying th
    helm install kube-prometheus-stack prometheus-community/kube-prometheus-stack
    ```
 
+> **Note:** When monitoring is enabled you must set `monitoring.prometheus.url` to point to your Prometheus instance
+> so that the conductor can query metrics. This is required regardless of how Prometheus was installed (operator, standalone, etc.).
+> For example, if you installed `kube-prometheus-stack` in the `monitoring` namespace with default settings:
+> ```yaml
+> monitoring:
+>   prometheus:
+>     url: "http://kube-prometheus-stack-prometheus.monitoring.svc.cluster.local:9090"
+> ```
+
 > **Note:** The OTel Collector must include the **Prometheus exporter**. The base `otelcol` distribution
 > includes it, but when the OTel Operator is installed via Helm it defaults to the `otelcol-k8s` distribution
 > which does **not**. If your operator uses the `k8s` distribution, set `monitoring.otel.collector.image`
@@ -108,7 +117,7 @@ The following operators must be installed in the cluster **before** deploying th
 | monitoring.otel.collector.exporters.prometheus.port | Prometheus exporter listen port                                                                                                                                                 | 8889                                       |
 | monitoring.otel.collector.exporters.prometheus.resourceToTelemetryConversion | Convert OTel resource attributes to Prometheus labels                                                                                                    | true                                       |
 | monitoring.otel.collector.exporters.prometheus.constLabels | Static labels added to all exported metrics                                                                                                                              | {platform: debezium}                       |
-| monitoring.prometheus.external.url         | URL of an external Prometheus instance (for users not using Prometheus Operator)                                                                                                        | ""                                         |
+| monitoring.prometheus.url                  | URL of the Prometheus instance used by the conductor to query metrics. **Required** when `monitoring.otel.enabled` is `true`.                                                          | ""                                         |
 | monitoring.prometheus.serviceMonitor.enabled | Create a ServiceMonitor for automatic Prometheus scraping. Requires the Prometheus Operator to be installed (see Prerequisites).                                                      | true                                       |
 | monitoring.prometheus.serviceMonitor.scrapeInterval | Prometheus scrape interval                                                                                                                                                    | 15s                                        |
 | monitoring.prometheus.serviceMonitor.labels | Labels for Prometheus Operator ServiceMonitor discovery                                                                                                                                | {prometheus: kube-prometheus}              |

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -117,6 +117,13 @@ Result: PIPELINE_LABELS_ARGOCD_ARGOPROJ_IO_INSTANCE
 {{- end -}}
 
 {{/*
+Get the Prometheus URL. Required when monitoring.otel.enabled is true.
+*/}}
+{{- define "debezium-platform.prometheusUrl" -}}
+{{- required "monitoring.prometheus.url is required when monitoring.otel.enabled is true" .Values.monitoring.prometheus.url -}}
+{{- end -}}
+
+{{/*
 Get the OpenTelemetry Collector resource name.
 */}}
 {{- define "debezium-platform.otelCollectorName" -}}

--- a/helm/templates/conductor-deployment.yaml
+++ b/helm/templates/conductor-deployment.yaml
@@ -76,6 +76,8 @@ spec:
               value: "true"
             - name: PIPELINE_MONITORING_OTEL_ENDPOINT
               value: {{ include "debezium-platform.otelCollectorEndpoint" . }}
+            - name: MONITORING_PROMETHEUS_URL
+              value: {{ include "debezium-platform.prometheusUrl" . }}
 {{- end }}
 {{- if .Values.monitoring.panels.additionalPanelsPath }}
             - name: MONITORING_PANELS_PATH

--- a/helm/tests/monitoring_test.yaml
+++ b/helm/tests/monitoring_test.yaml
@@ -11,6 +11,7 @@ tests:
     template: otel-collector.yaml
     set:
       monitoring.otel.enabled: true
+      monitoring.prometheus.url: "http://prometheus:9090"
     asserts:
       - isKind:
           of: OpenTelemetryCollector
@@ -47,6 +48,7 @@ tests:
     template: otel-collector.yaml
     set:
       monitoring.otel.enabled: true
+      monitoring.prometheus.url: "http://prometheus:9090"
       monitoring.otel.collector.replicas: 3
     asserts:
       - equal:
@@ -57,6 +59,7 @@ tests:
     template: otel-collector.yaml
     set:
       monitoring.otel.enabled: true
+      monitoring.prometheus.url: "http://prometheus:9090"
       monitoring.otel.collector.receivers.grpc.port: 14317
       monitoring.otel.collector.receivers.http.port: 14318
     asserts:
@@ -71,6 +74,7 @@ tests:
     template: otel-collector.yaml
     set:
       monitoring.otel.enabled: true
+      monitoring.prometheus.url: "http://prometheus:9090"
       monitoring.otel.collector.processors.batch.timeout: 10s
       monitoring.otel.collector.processors.batch.sendBatchSize: 1024
     asserts:
@@ -85,6 +89,7 @@ tests:
     template: otel-collector.yaml
     set:
       monitoring.otel.enabled: true
+      monitoring.prometheus.url: "http://prometheus:9090"
       monitoring.otel.collector.exporters.prometheus.port: 9090
     asserts:
       - equal:
@@ -95,6 +100,7 @@ tests:
     template: otel-collector.yaml
     set:
       monitoring.otel.enabled: true
+      monitoring.prometheus.url: "http://prometheus:9090"
     asserts:
       - equal:
           path: spec.config.service.pipelines.metrics.receivers
@@ -114,6 +120,7 @@ tests:
     template: servicemonitor.yaml
     set:
       monitoring.otel.enabled: true
+      monitoring.prometheus.url: "http://prometheus:9090"
       monitoring.prometheus.serviceMonitor.enabled: true
     asserts:
       - isKind:
@@ -147,6 +154,7 @@ tests:
     template: servicemonitor.yaml
     set:
       monitoring.otel.enabled: true
+      monitoring.prometheus.url: "http://prometheus:9090"
       monitoring.prometheus.serviceMonitor.enabled: false
     asserts:
       - hasDocuments:
@@ -156,6 +164,7 @@ tests:
     template: servicemonitor.yaml
     set:
       monitoring.otel.enabled: true
+      monitoring.prometheus.url: "http://prometheus:9090"
       monitoring.prometheus.serviceMonitor.enabled: true
       monitoring.prometheus.serviceMonitor.labels:
         release: my-prometheus
@@ -168,6 +177,7 @@ tests:
     template: servicemonitor.yaml
     set:
       monitoring.otel.enabled: true
+      monitoring.prometheus.url: "http://prometheus:9090"
       monitoring.prometheus.serviceMonitor.enabled: true
       monitoring.prometheus.serviceMonitor.scrapeInterval: 30s
     asserts:
@@ -180,6 +190,7 @@ tests:
     template: conductor-deployment.yaml
     set:
       monitoring.otel.enabled: true
+      monitoring.prometheus.url: "http://prometheus:9090"
     asserts:
       - contains:
           path: spec.template.spec.containers[0].env
@@ -192,6 +203,11 @@ tests:
             name: PIPELINE_MONITORING_OTEL_ENDPOINT
             value: "http://debezium-platform-otel-collector-collector.NAMESPACE.svc.cluster.local:4318"
           any: true
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MONITORING_PROMETHEUS_URL
+            value: "http://prometheus:9090"
 
   - it: should not inject monitoring env vars when monitoring.otel.enabled is false
     template: conductor-deployment.yaml
@@ -207,6 +223,11 @@ tests:
           path: spec.template.spec.containers[0].env
           content:
             name: PIPELINE_MONITORING_OTEL_ENDPOINT
+          any: true
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MONITORING_PROMETHEUS_URL
           any: true
 
   - it: should set MONITORING_PANELS_PATH when additionalPanelsPath is configured
@@ -228,3 +249,11 @@ tests:
           content:
             name: MONITORING_PANELS_PATH
           any: true
+
+  - it: should fail when monitoring.otel.enabled is true but monitoring.prometheus.url is not set
+    template: conductor-deployment.yaml
+    set:
+      monitoring.otel.enabled: true
+    asserts:
+      - failedTemplate:
+          errorMessage: "monitoring.prometheus.url is required when monitoring.otel.enabled is true"

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -85,8 +85,7 @@ monitoring:
   panels:
     additionalPanelsPath: ""
   prometheus:
-    external:
-      url: ""
+    url: ""
     serviceMonitor:
       enabled: true
       scrapeInterval: 15s


### PR DESCRIPTION
<!-- Make sure all your commits are signed before submitting your pull request -->
<!-- Run `git commit -s` to sign off your commits to satisfy the DCO check -->
<!-- Ensure your commit messages start with your GitHub issue, e.g., debezium/dbz#<issue_number> -->
Fixes debezium/dbz#2142

## Description
This pull request improves the configuration and validation of Prometheus integration when monitoring is enabled in the Helm charts. The main focus is to ensure that the Prometheus URL is explicitly set and validated when OpenTelemetry (OTel) monitoring is enabled, providing clearer documentation, stricter validation, and improved test coverage.

## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [X] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [X] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [X] One feature/change per PR unless tightly coupled
- [X] Do a rebase on upstream `main`
