### PR TITLE
debezium/dbz#2087 Add runtime deployment mode selection for host-based pipeline deployment

### DIFF
--- a/debezium-platform-conductor/src/main/java/io/debezium/platform/domain/PipelineService.java
+++ b/debezium-platform-conductor/src/main/java/io/debezium/platform/domain/PipelineService.java
@@ -5,12 +5,12 @@
  */
 package io.debezium.platform.domain;
 
-import java.util.List;
 import java.util.Optional;
 import java.util.function.Consumer;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.event.Event;
+import jakarta.enterprise.inject.Instance;
 import jakarta.persistence.EntityManager;
 import jakarta.transaction.Transactional;
 
@@ -25,7 +25,6 @@ import io.debezium.platform.domain.views.flat.PipelineFlat;
 import io.debezium.platform.domain.views.refs.PipelineReference;
 import io.debezium.platform.environment.EnvironmentController;
 import io.debezium.platform.environment.watcher.events.PipelineEvent;
-import io.quarkus.arc.All;
 
 @ApplicationScoped
 public class PipelineService extends AbstractService<PipelineEntity, Pipeline, PipelineReference> {
@@ -33,7 +32,7 @@ public class PipelineService extends AbstractService<PipelineEntity, Pipeline, P
     private final Event<ExportedEvent<?, ?>> event;
     private final ObjectMapper objectMapper;
     private final LogStreamingService logStreamer;
-    private final List<EnvironmentController> environmentControllers;
+    private final Instance<EnvironmentController> environmentController;
 
     public PipelineService(EntityManager em,
                            CriteriaBuilderFactory cbf,
@@ -41,12 +40,12 @@ public class PipelineService extends AbstractService<PipelineEntity, Pipeline, P
                            Event<ExportedEvent<?, ?>> event,
                            ObjectMapper objectMapper,
                            LogStreamingService logStreamer,
-                           @All List<EnvironmentController> environmentControllers) {
+                           Instance<EnvironmentController> environmentController) {
         super(PipelineEntity.class, Pipeline.class, PipelineReference.class, em, cbf, evm);
         this.event = event;
         this.objectMapper = objectMapper;
         this.logStreamer = logStreamer;
-        this.environmentControllers = environmentControllers;
+        this.environmentController = environmentController;
     }
 
     @Override
@@ -69,8 +68,7 @@ public class PipelineService extends AbstractService<PipelineEntity, Pipeline, P
      * @return {@link EnvironmentController} instance for the given pipeline
      */
     public Optional<EnvironmentController> environmentController(Long id) {
-        // TODO: only operator environment is supported currently;
-        return findById(id).map(pipeline -> environmentControllers.getFirst());
+        return findById(id).map(pipeline -> environmentController.get());
     }
 
     /**

--- a/debezium-platform-conductor/src/main/java/io/debezium/platform/environment/host/HostEnvironmentController.java
+++ b/debezium-platform-conductor/src/main/java/io/debezium/platform/environment/host/HostEnvironmentController.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.platform.environment.host;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.jboss.logging.Logger;
+
+import io.debezium.platform.environment.EnvironmentController;
+import io.debezium.platform.environment.PipelineController;
+import io.debezium.platform.environment.VaultController;
+import io.quarkus.arc.lookup.LookupIfProperty;
+
+/**
+ * Host-mode implementation of {@link EnvironmentController}.
+ * <p>
+ * Activated when {@code debezium.deployment.mode=host} is set at runtime.
+ * Both this and {@link io.debezium.platform.environment.operator.OperatorEnvironmentController}
+ * exist in the CDI container at all times &mdash;
+ * {@link io.quarkus.arc.lookup.LookupIfProperty} filters which one is returned
+ * by {@link jakarta.enterprise.inject.Instance#get()}.
+ * Every new {@code @ApplicationScoped} bean in the {@code environment/host/}
+ * package that has any startup behavior ({@code @Observes StartupEvent},
+ * {@code @Scheduled}) MUST include a runtime guard at the top of that method:
+ * <pre>
+ *   if (!"host".equals(deploymentMode)) return;
+ * </pre>
+ * {@code @LookupIfProperty} has NO effect on {@code @Observes} or
+ * {@code @Scheduled} &mdash; only on {@code Instance<T>.get()}.
+ * Without the guard, those methods will fire in operator mode and crash
+ * (e.g., trying to watch {@code ~/.ssh/config} inside container).
+ */
+@ApplicationScoped
+@LookupIfProperty(name = "debezium.deployment.mode", stringValue = "host")
+public class HostEnvironmentController implements EnvironmentController {
+
+    private final Logger logger;
+    private final HostVaultController vaultController;
+
+    public HostEnvironmentController(Logger logger, HostVaultController vaultController) {
+        this.logger = logger;
+        this.vaultController = vaultController;
+        logger.info("Host deployment mode activated");
+    }
+
+    @Override
+    public PipelineController pipelines() {
+        // TODO: Replace with HostPipelineController
+        throw new UnsupportedOperationException(
+                "Host pipeline controller not yet implemented");
+    }
+
+    @Override
+    public VaultController vaults() {
+        return vaultController;
+    }
+}

--- a/debezium-platform-conductor/src/main/java/io/debezium/platform/environment/host/HostVaultController.java
+++ b/debezium-platform-conductor/src/main/java/io/debezium/platform/environment/host/HostVaultController.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.platform.environment.host;
+
+import jakarta.enterprise.context.Dependent;
+
+import io.debezium.platform.domain.views.Vault;
+import io.debezium.platform.environment.VaultController;
+
+@Dependent
+public class HostVaultController implements VaultController {
+
+    @Override
+    public void deploy(Vault vault) {
+        // No-op: host mode does not use the Kubernetes operator vault integration
+    }
+
+    @Override
+    public void undeploy(Long id) {
+        // No-op: host mode does not use the Kubernetes operator vault integration
+    }
+}

--- a/debezium-platform-conductor/src/main/java/io/debezium/platform/environment/operator/DevClusterInitializer.java
+++ b/debezium-platform-conductor/src/main/java/io/debezium/platform/environment/operator/DevClusterInitializer.java
@@ -67,7 +67,10 @@ public class DevClusterInitializer {
             crds.resource(crd).serverSideApply();
         }
         catch (MalformedURLException e) {
-            throw new RuntimeException(e);
+            throw new RuntimeException("Invalid CRD URL: " + crdUrl, e);
+        }
+        catch (io.fabric8.kubernetes.client.KubernetesClientException e) {
+            logger.warnf("Failed to install CRD from %s. Kubernetes cluster might not be available: %s", crdUrl, e.getMessage());
         }
     }
 

--- a/debezium-platform-conductor/src/main/java/io/debezium/platform/environment/operator/OperatorEnvironmentController.java
+++ b/debezium-platform-conductor/src/main/java/io/debezium/platform/environment/operator/OperatorEnvironmentController.java
@@ -13,8 +13,10 @@ import org.jboss.logging.Logger;
 import io.debezium.platform.environment.EnvironmentController;
 import io.debezium.platform.environment.PipelineController;
 import io.debezium.platform.environment.VaultController;
+import io.quarkus.arc.lookup.LookupIfProperty;
 
 @ApplicationScoped
+@LookupIfProperty(name = "debezium.deployment.mode", stringValue = "operator", lookupIfMissing = true)
 @Named(OperatorEnvironmentController.BEAN_NAME)
 public class OperatorEnvironmentController implements EnvironmentController {
     public static final String BEAN_NAME = "operator-environment-controller";

--- a/debezium-platform-conductor/src/main/java/io/debezium/platform/environment/watcher/consumers/AbstractEventConsumer.java
+++ b/debezium-platform-conductor/src/main/java/io/debezium/platform/environment/watcher/consumers/AbstractEventConsumer.java
@@ -5,6 +5,8 @@
  */
 package io.debezium.platform.environment.watcher.consumers;
 
+import jakarta.enterprise.inject.Instance;
+
 import org.jboss.logging.Logger;
 
 import com.blazebit.persistence.integration.jackson.EntityViewAwareObjectMapper;
@@ -24,9 +26,10 @@ public abstract class AbstractEventConsumer<T> implements EnvironmentEventConsum
     // This is required to correctly deserialize EntityView see: https://persistence.blazebit.com/documentation/1.6/entity-view/manual/en_US/#usage-5
     protected final EntityViewAwareObjectMapper mapper;
 
-    public AbstractEventConsumer(Logger logger, EnvironmentController environment, ObjectMapper objectMapper, EntityViewManager evm, Class<T> payloadType) {
+    public AbstractEventConsumer(Logger logger, Instance<EnvironmentController> environmentInstance, ObjectMapper objectMapper, EntityViewManager evm,
+                                 Class<T> payloadType) {
         this.logger = logger;
-        this.environment = environment;
+        this.environment = environmentInstance.get();
         this.objectMapper = objectMapper;
         this.evm = evm;
         this.payloadType = payloadType;

--- a/debezium-platform-conductor/src/main/java/io/debezium/platform/environment/watcher/consumers/PipelineConsumer.java
+++ b/debezium-platform-conductor/src/main/java/io/debezium/platform/environment/watcher/consumers/PipelineConsumer.java
@@ -10,6 +10,7 @@ import java.util.List;
 import java.util.Optional;
 
 import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.inject.Instance;
 
 import org.jboss.logging.Logger;
 
@@ -23,7 +24,7 @@ import io.debezium.platform.environment.watcher.events.EventType;
 @Dependent
 public class PipelineConsumer extends AbstractEventConsumer<PipelineFlat> {
 
-    public PipelineConsumer(Logger logger, EnvironmentController environment, ObjectMapper objectMapper, EntityViewManager evm) {
+    public PipelineConsumer(Logger logger, Instance<EnvironmentController> environment, ObjectMapper objectMapper, EntityViewManager evm) {
         super(logger, environment, objectMapper, evm, PipelineFlat.class);
     }
 

--- a/debezium-platform-conductor/src/main/java/io/debezium/platform/environment/watcher/consumers/VaultConsumer.java
+++ b/debezium-platform-conductor/src/main/java/io/debezium/platform/environment/watcher/consumers/VaultConsumer.java
@@ -10,6 +10,7 @@ import java.util.List;
 import java.util.Optional;
 
 import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.inject.Instance;
 
 import org.jboss.logging.Logger;
 
@@ -23,7 +24,7 @@ import io.debezium.platform.environment.watcher.events.EventType;
 @Dependent
 public class VaultConsumer extends AbstractEventConsumer<Vault> {
 
-    public VaultConsumer(Logger logger, EnvironmentController environment, ObjectMapper objectMapper, EntityViewManager evm) {
+    public VaultConsumer(Logger logger, Instance<EnvironmentController> environment, ObjectMapper objectMapper, EntityViewManager evm) {
         super(logger, environment, objectMapper, evm, Vault.class);
     }
 

--- a/debezium-platform-conductor/src/test/java/io/debezium/platform/environment/host/HostModeTestProfile.java
+++ b/debezium-platform-conductor/src/test/java/io/debezium/platform/environment/host/HostModeTestProfile.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.platform.environment.host;
+
+import java.util.Map;
+
+import io.quarkus.test.junit.QuarkusTestProfile;
+
+/**
+ * Test profile that sets {@code debezium.deployment.mode=host} to activate
+ * the host deployment path for CDI bean selection tests.
+ */
+public class HostModeTestProfile implements QuarkusTestProfile {
+
+    @Override
+    public Map<String, String> getConfigOverrides() {
+        return Map.of(
+                "debezium.deployment.mode", "host",
+                "quarkus.oras.devservices.base-port", "25001");
+    }
+
+    @Override
+    public String getConfigProfile() {
+        return "test";
+    }
+}

--- a/debezium-platform-conductor/src/test/java/io/debezium/platform/environment/host/HostModeWiringIT.java
+++ b/debezium-platform-conductor/src/test/java/io/debezium/platform/environment/host/HostModeWiringIT.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.platform.environment.host;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+
+import io.debezium.platform.environment.EnvironmentController;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+
+/**
+ * Verifies that CDI bean selection via {@code @LookupIfProperty} correctly
+ * activates {@link HostEnvironmentController} when
+ * {@code debezium.deployment.mode=host}.
+ */
+@QuarkusTest
+@TestProfile(HostModeTestProfile.class)
+public class HostModeWiringIT {
+
+    @Inject
+    Instance<EnvironmentController> environmentController;
+
+    @Test
+    public void shouldActivateHostControllerWhenModeIsHost() {
+        assertThat(environmentController.isResolvable())
+                .as("Exactly one EnvironmentController should be resolvable in host mode")
+                .isTrue();
+
+        var controller = environmentController.get();
+        assertThat(controller)
+                .as("The resolved controller should be HostEnvironmentController")
+                .isInstanceOf(HostEnvironmentController.class);
+    }
+
+    @Test
+    public void shouldProvideHostVaultController() {
+        var controller = environmentController.get();
+        assertThat(controller.vaults())
+                .as("Host mode vaults() should return HostVaultController")
+                .isInstanceOf(HostVaultController.class);
+    }
+}

--- a/debezium-platform-conductor/src/test/resources/application.properties
+++ b/debezium-platform-conductor/src/test/resources/application.properties
@@ -1,2 +1,6 @@
 quarkus.rest-client.logging.scope=request-response
 quarkus.log.category."org.jboss.resteasy.reactive.client.logging".level=DEBUG
+# Custom test properties
+# Overriding the default port (5000) to avoid conflicts with macOS AirPlay Receiver during local tests
+quarkus.oras.devservices.base-port=25000
+


### PR DESCRIPTION
Fixes debezium/dbz#2087

## Description

Introduces runtime deployment mode selection (`debezium.deployment.mode`) to allow the platform to run in either `operator` (Kubernetes) or `host`(bare-metal/VM) mode from the same image.

Both `OperatorEnvironmentController` and `HostEnvironmentController` are annotated with `@LookupIfProperty`, so CDI resolves the correct one at runtime based on the property value. The operator path remains the default when the property is unset (`lookupIfMissing = true`), so existing deployments are unaffected.

Injection sites that previously used `@All List<EnvironmentController>` or direct `EnvironmentController` injection have been switched to `Instance<EnvironmentController>` to support the runtime lookup.

### Changes

- Add `@LookupIfProperty` to `OperatorEnvironmentController`
- Add `HostEnvironmentController` and `HostVaultController` for the host path
- Switch `PipelineService`, `AbstractEventConsumer`, `PipelineConsumer`, and
  `VaultConsumer` to `Instance<EnvironmentController>`
- Gracefully handle missing Kubernetes cluster in `DevClusterInitializer`
- Add `HostModeWiringIT` to verify bean selection in host mode

## PR Checklist

- [X] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [X] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [X] One feature/change per PR unless tightly coupled
- [X] Do a rebase on upstream `main`
