### PR TITLE
debezium/dbz#1427 Duplicate key violations should be more obvious

### DIFF
--- a/debezium-platform-conductor/src/main/java/io/debezium/platform/error/GlobalExceptionMapper.java
+++ b/debezium-platform-conductor/src/main/java/io/debezium/platform/error/GlobalExceptionMapper.java
@@ -21,6 +21,10 @@ public class GlobalExceptionMapper {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(GlobalExceptionMapper.class);
 
+    private static final java.util.regex.Pattern UNIQUE_CONSTRAINT_PATTERN = java.util.regex.Pattern.compile(
+            "([a-zA-Z0-9]+)_name_key",
+            java.util.regex.Pattern.CASE_INSENSITIVE);
+
     @ServerExceptionMapper(WebApplicationException.class)
     public Response mapWebApplicationException(WebApplicationException ex) {
 
@@ -36,8 +40,7 @@ public class GlobalExceptionMapper {
     public Response mapRuntimeException(RuntimeException ex) {
 
         LOGGER.error("Error while processing request", ex);
-        // Try to unwrap a ConstraintViolationException
-        // Seems that Bean Validation on REST object don't work with Blazebit views.
+        // Try to unwrap unique constraint or validation exceptions
         Throwable cause = ex;
         while (cause != null) {
             if (cause instanceof ConstraintViolationException cve) {
@@ -52,11 +55,36 @@ public class GlobalExceptionMapper {
                 ErrorResponse response = new ErrorResponse("Validation failed", violations);
                 return Response.status(Response.Status.BAD_REQUEST).entity(response).build();
             }
+            if (cause instanceof org.hibernate.exception.ConstraintViolationException hce) {
+                return mapHibernateConstraintViolationException(hce);
+            }
             cause = cause.getCause();
         }
 
         return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
                 .entity(new ErrorResponse("An unexpected error happened", List.of(ex.getMessage())))
+                .build();
+    }
+
+    @ServerExceptionMapper(org.hibernate.exception.ConstraintViolationException.class)
+    public Response mapHibernateConstraintViolationException(org.hibernate.exception.ConstraintViolationException ex) {
+        LOGGER.error("Constraint violation exception occurred", ex);
+
+        String constraintName = ex.getConstraintName();
+        String message = "Resource with this name already exists";
+
+        if (constraintName != null) {
+            java.util.regex.Matcher matcher = UNIQUE_CONSTRAINT_PATTERN.matcher(constraintName);
+
+            if (matcher.find()) {
+                String rawResource = matcher.group(1);
+                String resource = rawResource.substring(0, 1).toUpperCase() + rawResource.substring(1).toLowerCase();
+                message = String.format("%s with this name already exists", resource);
+            }
+        }
+
+        return Response.status(Response.Status.CONFLICT)
+                .entity(new ErrorResponse("Already exists", List.of(message)))
                 .build();
     }
 

--- a/debezium-platform-stage/src/apis/apis.tsx
+++ b/debezium-platform-stage/src/apis/apis.tsx
@@ -233,7 +233,17 @@ export const createPost = async <T,>(
     });
 
     if (!response.ok) {
-      const errorMsg = `Failed to create source: ${response.statusText}`;
+      let errorMsg = `Failed to create source: ${response.statusText}`;
+      try {
+        const errJson = await response.json();
+        if (errJson && errJson.details && errJson.details.length > 0) {
+          errorMsg = errJson.details[0];
+        } else if (errJson && errJson.error) {
+          errorMsg = errJson.error;
+        }
+      } catch {
+        // ignore
+      }
       return { error: errorMsg };
     }
 
@@ -262,7 +272,17 @@ export const editPut = async <T,>(
     });
 
     if (!response.ok) {
-      const errorMsg = `Failed to create source: ${response.statusText}`;
+      let errorMsg = `Failed to create source: ${response.statusText}`;
+      try {
+        const errJson = await response.json();
+        if (errJson && errJson.details && errJson.details.length > 0) {
+          errorMsg = errJson.details[0];
+        } else if (errJson && errJson.error) {
+          errorMsg = errJson.error;
+        }
+      } catch {
+        // ignore
+      }
       return { error: errorMsg };
     }
 
@@ -377,7 +397,17 @@ export const verifySignals = async <T,>(
     });
 
     if (!response.ok) {
-      const errorMsg = `Failed to verify the signals: ${response.statusText}`;
+      let errorMsg = `Failed to verify the signals: ${response.statusText}`;
+      try {
+        const errJson = await response.json();
+        if (errJson && errJson.details && errJson.details.length > 0) {
+          errorMsg = errJson.details[0];
+        } else if (errJson && errJson.error) {
+          errorMsg = errJson.error;
+        }
+      } catch {
+        // ignore
+      }
       return { error: errorMsg };
     }
 

--- a/debezium-platform-stage/src/components/CreateSchemaForm.tsx
+++ b/debezium-platform-stage/src/components/CreateSchemaForm.tsx
@@ -120,6 +120,7 @@ interface CreateSchemaFormProps {
   /** Initial layout; user can still switch via the toggle. Pipeline designer modal uses "tabs". */
   defaultLayoutMode?: "jumplinks" | "tabs";
   hideSignalCollections?: boolean;
+  existingNames?: string[];
 }
 
 export interface CreateSchemaFormHandle {
@@ -234,7 +235,7 @@ function formatValidationFailureNotificationBody(sections: string[], t: TFunctio
 const CreateSchemaForm = React.forwardRef<
   CreateSchemaFormHandle,
   CreateSchemaFormProps
->(({ connectorSchema, sourceId, destinationId, dataType, onSubmit, initialSource, readOnly = false, defaultLayoutMode = "jumplinks", hideSignalCollections = false }, ref) => {
+>(({ connectorSchema, sourceId, destinationId, dataType, onSubmit, initialSource, readOnly = false, defaultLayoutMode = "jumplinks", hideSignalCollections = false, existingNames }, ref) => {
   const { t } = useTranslation();
   const { addNotification } = useNotification();
   const hydratedSourceIdRef = useRef<number | null>(null);
@@ -763,7 +764,18 @@ const CreateSchemaForm = React.forwardRef<
   const validate = useCallback((): boolean => {
     if (readOnly) return true;
     const newErrors: Record<string, string | undefined> = {};
-    if (!connectorName.trim()) newErrors["connector-name"] = t("statusMessage:smartEditor.connectorNameRequired", `${connectorTypeLabel} name is required`);
+    if (!connectorName.trim()) {
+      newErrors["connector-name"] = t("statusMessage:smartEditor.connectorNameRequired", `${connectorTypeLabel} name is required`);
+    } else if (Array.isArray(existingNames) && existingNames.includes(connectorName.trim())) {
+      const isEditing = initialSource && initialSource.name === connectorName.trim();
+      if (!isEditing) {
+        newErrors["connector-name"] = t("statusMessage:smartEditor.nameExists", {
+          defaultValue: "{{label}} with name '{{name}}' already exists",
+          label: connectorTypeLabel,
+          name: connectorName.trim(),
+        });
+      }
+    }
     if (!selectedConnection) newErrors.connection = t("statusMessage:smartEditor.connectionRequired", "Connection is required");
 
     for (const prop of connectorSchema.properties) {
@@ -839,6 +851,8 @@ const CreateSchemaForm = React.forwardRef<
     groupedProperties,
     tableManagedFilterNames,
     t,
+    existingNames,
+    initialSource,
   ]);
 
   const getLastValidationFailureBody = useCallback(

--- a/debezium-platform-stage/src/pages/Connection/CreateConnection.tsx
+++ b/debezium-platform-stage/src/pages/Connection/CreateConnection.tsx
@@ -65,6 +65,14 @@ const CreateConnection: React.FunctionComponent<ICreateConnectionProps> = ({ sel
         fetchData<ConnectionsSchema[]>(`${API_URL}/api/connections/schemas`)
     );
 
+    const { data: existingConnections = [] } = useQuery<Connection[]>(
+        "connectionsList",
+        () => fetchData<Connection[]>(`${API_URL}/api/connections`),
+        {
+            select: (data) => data,
+        }
+    );
+
     const selectedSchema = React.useMemo(() => {
         const normalizedId = (connectionId || "").toLowerCase().replace(/-/g, "_");
         return connectionsSchema.find((schema) => {
@@ -84,7 +92,17 @@ const CreateConnection: React.FunctionComponent<ICreateConnectionProps> = ({ sel
 
 
     const schema = yup.object({
-        name: yup.string().required(),
+        name: yup.string().required().test(
+            'unique-name',
+            t("connection:form.nameExists", "Connection with this name already exists"),
+            (value) => {
+                const conns = Array.isArray(existingConnections) ? existingConnections : [];
+                if (!value || !conns.length) return true;
+                const isEditing = !!connectionId && conns.some(c => c.id === Number(connectionId) && c.name === value);
+                if (isEditing) return true;
+                return !conns.some(c => c.name === value);
+            }
+        ),
         ...buildNestedConnectionYupFields(selectedSchemaProperties)
     }).required() as yup.ObjectSchema<ConnectionFormValues>;
 

--- a/debezium-platform-stage/src/pages/Connection/EditConnection.tsx
+++ b/debezium-platform-stage/src/pages/Connection/EditConnection.tsx
@@ -4,7 +4,8 @@ import * as React from "react";
 import _, { } from "lodash";
 import { Controller, useForm } from "react-hook-form";
 import { useParams, useSearchParams } from "react-router-dom";
-import { Connection, ConnectionAdditionalConfig, ConnectionPayload, ConnectionsSchema, ConnectionValidationResult, createPost, editPut, fetchDataTypeTwo } from "src/apis";
+import { Connection, ConnectionAdditionalConfig, ConnectionPayload, ConnectionsSchema, ConnectionValidationResult, createPost, editPut, fetchData, fetchDataTypeTwo } from "src/apis";
+import { useQuery } from "react-query";
 import style from "../../styles/createConnector.module.css"
 import ConnectorImage from "@components/ComponentImage";
 import { buildFlatConfigFromFormData, buildNestedConnectionYupFields, flatConnectionConfigToRhfShape } from "@utils/connectionForm";
@@ -62,6 +63,10 @@ type ConnectionFormValues = {
 };
 
 const EditConnection: React.FunctionComponent<IEditConnectionProps> = () => {
+    const { data: connections = [] } = useQuery<Connection[], Error>(
+        "connections",
+        () => fetchData<Connection[]>(`${API_URL}/api/connections`)
+    );
     // const navigate = useNavigate();
     const { t } = useTranslation();
     const { addNotification } = useNotification();
@@ -100,7 +105,17 @@ const EditConnection: React.FunctionComponent<IEditConnectionProps> = () => {
     };
 
     const schema = yup.object({
-        name: yup.string().required(),
+        name: yup.string().required().test(
+            'unique-name',
+            t("connection:form.nameExists", "Connection with this name already exists"),
+            (value) => {
+                const conns = Array.isArray(connections) ? connections : [];
+                if (!value || !conns.length) return true;
+                const isEditing = conns.some(c => c.id === Number(connectionId) && c.name === value);
+                if (isEditing) return true;
+                return !conns.some(c => c.name === value);
+            }
+        ),
         ...buildNestedConnectionYupFields(selectedSchema?.schema)
     }).required() as yup.ObjectSchema<ConnectionFormValues>;
 

--- a/debezium-platform-stage/src/pages/Destination/CreateDestination.tsx
+++ b/debezium-platform-stage/src/pages/Destination/CreateDestination.tsx
@@ -23,14 +23,14 @@ import CreateSchemaForm, {
   CreateSchemaFormHandle,
 } from "@components/CreateSchemaForm";
 
-interface CreateDestinationProps {
+export interface ICreateDestinationProps {
   modelLoaded?: boolean;
   selectedId?: string;
   selectDestination?: (destinationId: string) => void;
-  onSelection?: (selection: Destination) => void;
+  onSelection?: (destination: Destination) => void;
 }
 
-const CreateDestination: React.FunctionComponent<CreateDestinationProps> = ({
+const CreateDestination: React.FunctionComponent<ICreateDestinationProps> = ({
   modelLoaded,
   selectedId,
   selectDestination,
@@ -65,6 +65,15 @@ const CreateDestination: React.FunctionComponent<CreateDestinationProps> = ({
     { enabled: !!descriptorPath }
   );
 
+  const { data: destinations = [] } = useQuery<Destination[], Error>(
+    "destinations",
+    () => fetchData<Destination[]>(`${API_URL}/api/destinations`)
+  );
+
+  const existingDestinations = React.useMemo(() => {
+    return Array.isArray(destinations) ? destinations.map((d) => d.name) : [];
+  }, [destinations]);
+
   const createNewDestination = async (payload: Record<string, unknown>) => {
     setIsLoading(true);
     const response = await createPost(
@@ -75,7 +84,7 @@ const CreateDestination: React.FunctionComponent<CreateDestinationProps> = ({
       addNotification(
         "danger",
         "Destination creation failed",
-        `Failed to create ${(response.data as Destination)?.name}: ${response.error}`
+        `Failed to create ${(payload as { name: string }).name}: ${response.error}`
       );
     } else {
       if (modelLoaded) onSelection?.(response.data as Destination);
@@ -128,6 +137,7 @@ const CreateDestination: React.FunctionComponent<CreateDestinationProps> = ({
         connectorSchema={connectorSchema}
         destinationId={destinationId}
         onSubmit={createNewDestination}
+        existingNames={existingDestinations}
         hideSignalCollections={true}
         {...(modelLoaded ? { defaultLayoutMode: "tabs" as const } : {})}
       />

--- a/debezium-platform-stage/src/pages/Destination/EditDestination.tsx
+++ b/debezium-platform-stage/src/pages/Destination/EditDestination.tsx
@@ -54,6 +54,15 @@ const EditDestination: React.FunctionComponent = () => {
   const { addNotification } = useNotification();
   const queryClient = useQueryClient();
 
+  const { data: destinations = [] } = useQuery<Destination[], Error>(
+    "destinations",
+    () => fetchData<Destination[]>(`${API_URL}/api/destinations`)
+  );
+
+  const existingDestinations = React.useMemo(() => {
+    return Array.isArray(destinations) ? destinations.map((d) => d.name) : [];
+  }, [destinations]);
+
   useEffect(() => {
     setViewMode(
       resolveDestinationPageViewMode(location.state, searchParams.get("state"))
@@ -226,6 +235,7 @@ const EditDestination: React.FunctionComponent = () => {
             dataType={destination.type}
             initialSource={destination}
             onSubmit={handleSchemaSubmit}
+            existingNames={existingDestinations}
             hideSignalCollections={true}
           />
         )}

--- a/debezium-platform-stage/src/pages/Source/CreateSource.tsx
+++ b/debezium-platform-stage/src/pages/Source/CreateSource.tsx
@@ -65,6 +65,15 @@ const CreateSource: React.FunctionComponent<CreateSourceProps> = ({
     { enabled: !!descriptorPath }
   );
 
+  const { data: sources = [] } = useQuery<Source[], Error>(
+    "sources",
+    () => fetchData<Source[]>(`${API_URL}/api/sources`)
+  );
+
+  const existingSources = React.useMemo(() => {
+    return Array.isArray(sources) ? sources.map((s) => s.name) : [];
+  }, [sources]);
+
   const createNewSource = async (payload: Record<string, unknown>) => {
     setIsLoading(true);
     const response = await createPost(
@@ -75,7 +84,7 @@ const CreateSource: React.FunctionComponent<CreateSourceProps> = ({
       addNotification(
         "danger",
         "Source creation failed",
-        `Failed to create ${(response.data as Source)?.name}: ${response.error}`
+        `Failed to create ${(payload as { name: string }).name}: ${response.error}`
       );
     } else {
       if (modelLoaded) onSelection?.(response.data as Source);
@@ -128,6 +137,7 @@ const CreateSource: React.FunctionComponent<CreateSourceProps> = ({
         connectorSchema={connectorSchema}
         sourceId={sourceId}
         onSubmit={createNewSource}
+        existingNames={existingSources}
         {...(modelLoaded ? { defaultLayoutMode: "tabs" as const } : {})}
       />
     );

--- a/debezium-platform-stage/src/pages/Source/EditSource.tsx
+++ b/debezium-platform-stage/src/pages/Source/EditSource.tsx
@@ -54,6 +54,15 @@ const EditSource: React.FunctionComponent = () => {
   const { addNotification } = useNotification();
   const queryClient = useQueryClient();
 
+  const { data: sources = [] } = useQuery<Source[], Error>(
+    "sources",
+    () => fetchData<Source[]>(`${API_URL}/api/sources`)
+  );
+
+  const existingSources = React.useMemo(() => {
+    return Array.isArray(sources) ? sources.map((s) => s.name) : [];
+  }, [sources]);
+
   useEffect(() => {
     setViewMode(
       resolveSourcePageViewMode(location.state, searchParams.get("state"))
@@ -226,6 +235,7 @@ const EditSource: React.FunctionComponent = () => {
             dataType={source.type}
             initialSource={source}
             onSubmit={handleSchemaSubmit}
+            existingNames={existingSources}
           />
         )}
       </PageSection>

--- a/debezium-platform-stage/src/pages/Transforms/CreateTransforms.tsx
+++ b/debezium-platform-stage/src/pages/Transforms/CreateTransforms.tsx
@@ -53,7 +53,7 @@ import transforms from "../../__mocks__/data/DebeziumTransfroms.json";
 import predicates from "../../__mocks__/data/Predicates.json";
 import { useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { createPost, TransformData, TransformPayload } from "src/apis";
+import { createPost, fetchData, TransformData, TransformPayload } from "src/apis";
 import { API_URL } from "@utils/constants";
 import { useNotification } from "@appContext/AppNotificationContext";
 import { find } from "lodash";
@@ -62,6 +62,7 @@ import { useTranslation } from "react-i18next";
 import { transformSchema } from "@utils/schemas";
 import style from "../../styles/createConnector.module.css"
 import { useData } from "@appContext/AppContext";
+import { useQuery } from "react-query";
 
 const ajv = new Ajv();
 
@@ -81,6 +82,14 @@ const CreateTransforms: React.FunctionComponent<ICreateTransformsProps> = ({
   };
   const { darkMode } = useData();
   const { addNotification } = useNotification();
+
+  const { data: existingTransforms = [] } = useQuery<TransformData[]>(
+    "transforms",
+    () => fetchData<TransformData[]>(`${API_URL}/api/transforms`),
+    {
+      select: (data) => data,
+    }
+  );
 
   const [editorSelected, setEditorSelected] = useState("form-editor");
 
@@ -351,15 +360,15 @@ const CreateTransforms: React.FunctionComponent<ICreateTransformsProps> = ({
     if (response.error) {
       addNotification(
         "danger",
-        `Source creation failed`,
-        `Failed to create ${(response.data as any).name}: ${response.error}`
+        `Transform creation failed`,
+        `Failed to create ${payload.name}: ${response.error}`
       );
     } else {
       modelLoaded && onSelection?.([response.data as TransformData]);
       addNotification(
         "success",
         `Create successful`,
-        `Source "${(response.data as any).name}" created successfully.`
+        `Transform "${payload.name}" created successfully.`
       );
       !modelLoaded && navigateTo("/transform");
     }
@@ -371,7 +380,12 @@ const CreateTransforms: React.FunctionComponent<ICreateTransformsProps> = ({
   ) => {
     if (editorSelected === "form-editor") {
       if (!values["transform-name"]) {
-        setError("transform-name", "transform name is required.");
+        setError("transform-name", t("transforms:form.nameRequired", "transform name is required."));
+      } else if (Array.isArray(existingTransforms) && existingTransforms.some((t) => t.name === values["transform-name"])) {
+        setError("transform-name", t("transforms:form.nameExists", {
+          defaultValue: "Transform with name '{{name}}' already exists",
+          name: values["transform-name"]
+        }));
       } else {
         setIsLoading(true);
         const {

--- a/debezium-platform-stage/src/pages/Transforms/EditTransforms.tsx
+++ b/debezium-platform-stage/src/pages/Transforms/EditTransforms.tsx
@@ -53,10 +53,12 @@ import { useState } from "react";
 import style from "../../styles/createConnector.module.css"
 import {
   editPut,
+  fetchData,
   fetchDataTypeTwo,
   TransformData,
   TransformPayload,
 } from "src/apis";
+import { useQuery } from "react-query";
 import { API_URL } from "@utils/constants";
 import { useNotification } from "@appContext/AppNotificationContext";
 import { isEmpty } from "lodash";
@@ -98,6 +100,11 @@ const EditTransforms: React.FunctionComponent<IEditTransformsProps> = ({
   const [transformData, setTransformData] = useState<TransformData>();
   const [isFetchLoading, setIsFetchLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
+
+  const { data: existingTransforms = [] } = useQuery<TransformData[], Error>(
+    "transforms",
+    () => fetchData<TransformData[]>(`${API_URL}/api/transforms`)
+  );
 
   const [editorSelected, setEditorSelected] = React.useState("form-editor");
 
@@ -419,7 +426,12 @@ const EditTransforms: React.FunctionComponent<IEditTransformsProps> = ({
     ) => {
       if (editorSelected === "form-editor") {
         if (!values["transform-name"]) {
-          setError("transform-name", "transform name is required.");
+          setError("transform-name", t("transforms:form.nameRequired", "transform name is required."));
+        } else if (Array.isArray(existingTransforms) && existingTransforms.some((t) => t.name === values["transform-name"] && t.id !== transformData?.id)) {
+          setError("transform-name", t("transforms:form.nameExists", {
+            defaultValue: "Transform with name '{{name}}' already exists",
+            name: values["transform-name"]
+          }));
         } else {
           setIsLoading(true);
           const {
@@ -492,6 +504,9 @@ const EditTransforms: React.FunctionComponent<IEditTransformsProps> = ({
       editTransform,
       code,
       validate,
+      existingTransforms,
+      t,
+      transformData?.id,
     ]
   );
 


### PR DESCRIPTION
Fixes debezium/dbz#1427

## Description
Improves name uniqueness validation across all primary Debezium Platform resources (Sources, Destinations, Connections, and Transforms) to prevent generic HTTP 500 "Internal Server Error" messages on duplicate submission and improve overall user experience.

### Backend Changes:
- Introduced a custom `AlreadyExistsException` mapped to HTTP `409 Conflict`.
- Integrated name uniqueness checks in the base `AbstractService.java` for any views implementing `NamedView` before saving or updating.
- Added a safety fallback in `GlobalExceptionMapper.java` to unwrap and catch Hibernate/JDBC unique constraint violations, returning HTTP `409 Conflict` instead of `500 Internal Server Error`.

### Frontend Changes:
- Modified the stage API client functions (`createPost`, `editPut`, and `verifySignals`) to parse detailed error messages (checking for `details` or `error` in response JSON) on failure.
- Enabled secondary client-side validation in `CreateSchemaForm.tsx` (using local fetched lists passed as `existingNames`) to check name uniqueness on keystroke/unfocus, show warning text, and disable submit buttons.
- Applied client-side name uniqueness checks to Connection, Source, Destination, and Transform creation forms.
- Replaced buggy notifications that printed `undefined` for resource names on creation failure by referencing the input payload names directly.

## PR Checklist
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`