### PR TITLE
debezium/dbz#2088 Add SSH config parser for host discovery

### DIFF
--- a/debezium-platform-conductor/src/main/java/io/debezium/platform/environment/host/discovery/SshConfigParser.java
+++ b/debezium-platform-conductor/src/main/java/io/debezium/platform/environment/host/discovery/SshConfigParser.java
@@ -1,0 +1,271 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.platform.environment.host.discovery;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.IntStream;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.jboss.logging.Logger;
+
+/**
+ * Parses an OpenSSH {@code ~/.ssh/config} file into a list of {@link SshHostEntry} records.
+ *
+ * <p>This is a pure, stateless parser with no database access, no SSH connectivity, and no
+ * file-watching behavior. It reads text and produces structured data — nothing more.
+ *
+ * <p>The public API is {@link #parse(Path)}, which reads a file and delegates to the
+ * package-visible {@link #parseLines(List)} method. The separation exists so that
+ * unit tests can call {@code parseContent} directly with string literals, avoiding the
+ * overhead of temporary files.
+ *
+ * <p>Parsing rules follow the {@code ssh_config(5)} specification:
+ * <ul>
+ *   <li>Keywords are case-insensitive; values are case-sensitive</li>
+ *   <li>Both whitespace and {@code =} are valid keyword-value delimiters</li>
+ *   <li>Inline comments (OpenSSH 8.5+) are stripped from values</li>
+ *   <li>Quoted values have surrounding double-quotes removed</li>
+ *   <li>Wildcard Host entries ({@code *}, {@code ?}, {@code !}) are skipped</li>
+ * </ul>
+ */
+@ApplicationScoped
+public class SshConfigParser {
+
+    private static final int DEFAULT_PORT = 22;
+    private static final int MIN_PORT = 1;
+    private static final int MAX_PORT = 65535;
+    private static final char EQUALS_DELIMITER = '=';
+    private static final char COMMENT_CHAR = '#';
+    private static final String WILDCARD_CHARS = "*?!";
+    private static final String HOST_KEYWORD = "host";
+
+    private final Logger logger;
+
+    public SshConfigParser(Logger logger) {
+        this.logger = logger;
+    }
+
+    /**
+     * Parses the SSH config file at the given path.
+     *
+     * @param configFilePath path to the SSH config file
+     * @return list of parsed host entries, never null
+     * @throws IOException if the file cannot be read
+     */
+    public List<SshHostEntry> parse(Path configFilePath) throws IOException {
+        logger.debugv("Parsing SSH config file: {0}", configFilePath);
+        List<String> lines = Files.readAllLines(configFilePath);
+        List<SshHostEntry> hostEntries = parseLines(lines);
+        logger.debugv("Found {0} host entries in SSH config", hostEntries.size());
+        return hostEntries;
+    }
+
+    /**
+     * Parses the given SSH config content string into host entries.
+     * Package-visible for unit test access.
+     */
+    List<SshHostEntry> parseContent(String content) {
+        return parseLines(Arrays.asList(content.split("\n", -1)));
+    }
+
+    /**
+     * Core parsing logic that operates on a list of lines.
+     */
+    private List<SshHostEntry> parseLines(List<String> lines) {
+        List<SshHostEntry> hostEntries = new ArrayList<>();
+        Set<String> seenAliases = new HashSet<>();
+
+        String currentAlias = null;
+        String currentHostname = null;
+        String currentUser = null;
+        int currentPort = DEFAULT_PORT;
+        String currentIdentityFile = null;
+
+        for (String line : lines) {
+            String stripped = line.strip();
+
+            if (isBlankOrComment(stripped)) {
+                continue;
+            }
+
+            String keyword;
+            String value;
+            int splitIndex = findDelimiterIndex(stripped);
+            if (splitIndex < 0) {
+                logger.warnv("Malformed line in SSH config (no keyword-value delimiter): {0}", stripped);
+                continue;
+            }
+
+            keyword = stripped.substring(0, splitIndex).strip().toLowerCase();
+            String rawValue = stripped.substring(splitIndex + 1).strip();
+
+            if (!rawValue.isEmpty() && rawValue.charAt(0) == EQUALS_DELIMITER) {
+                rawValue = rawValue.substring(1).strip();
+            }
+
+            if (rawValue.isEmpty()) {
+                logger.warnv("Malformed line in SSH config (empty value): {0}", stripped);
+                continue;
+            }
+
+            value = stripInlineComment(rawValue);
+            value = stripQuotes(value);
+
+            if (isHostLine(keyword)) {
+                if (currentAlias != null) {
+                    hostEntries.add(new SshHostEntry(currentAlias, currentHostname,
+                            currentUser, currentPort, currentIdentityFile));
+                }
+
+                if (isWildcard(value)) {
+                    logger.warnv("Skipping wildcard Host entry: {0}", value);
+                    currentAlias = null;
+                    currentHostname = null;
+                    currentUser = null;
+                    currentPort = DEFAULT_PORT;
+                    currentIdentityFile = null;
+                    continue;
+                }
+
+                if (!seenAliases.add(value)) {
+                    logger.warnv("Skipping duplicate Host alias: {0}", value);
+                    currentAlias = null;
+                    currentHostname = null;
+                    currentUser = null;
+                    currentPort = DEFAULT_PORT;
+                    currentIdentityFile = null;
+                    continue;
+                }
+
+                currentAlias = value;
+                currentHostname = null;
+                currentUser = null;
+                currentPort = DEFAULT_PORT;
+                currentIdentityFile = null;
+            }
+            else if (currentAlias != null) {
+                switch (keyword) {
+                    case "hostname":
+                        currentHostname = value;
+                        break;
+                    case "user":
+                        currentUser = value;
+                        break;
+                    case "port":
+                        int port = parsePort(value);
+                        if (port < 0) {
+                            logger.warnv("Skipping host entry ''{0}'' due to invalid port: {1}", currentAlias, value);
+                            currentAlias = null;
+                            currentHostname = null;
+                            currentUser = null;
+                            currentPort = DEFAULT_PORT;
+                            currentIdentityFile = null;
+                        }
+                        else {
+                            currentPort = port;
+                        }
+                        break;
+                    case "identityfile":
+                        currentIdentityFile = value;
+                        break;
+                    default:
+                        break;
+                }
+            }
+        }
+
+        if (currentAlias != null) {
+            hostEntries.add(new SshHostEntry(currentAlias, currentHostname,
+                    currentUser, currentPort, currentIdentityFile));
+        }
+
+        return hostEntries;
+    }
+
+    private boolean isBlankOrComment(String line) {
+        return line.isEmpty() || line.charAt(0) == COMMENT_CHAR;
+    }
+
+    private boolean isHostLine(String keyword) {
+        return HOST_KEYWORD.equals(keyword);
+    }
+
+    /**
+     * Finds the index of the first delimiter (whitespace or '=') in the line.
+     * Returns -1 if no delimiter is found.
+     */
+    private int findDelimiterIndex(String line) {
+        return IntStream.range(0, line.length())
+                .filter(i -> line.charAt(i) == EQUALS_DELIMITER || Character.isWhitespace(line.charAt(i)))
+                .findFirst()
+                .orElse(-1);
+    }
+
+    /**
+     * Strips an inline comment from the value. An inline comment starts at the first
+     * '#' that is not inside double quotes.
+     *
+     * <p>Example: {@code "deploy # production"} becomes {@code "deploy"}.
+     * <p>Example: {@code "\"path with # in it\""} preserves the '#' inside quotes.
+     */
+    private String stripInlineComment(String value) {
+        boolean inQuotes = false;
+        for (int i = 0; i < value.length(); i++) {
+            char c = value.charAt(i);
+            if (c == '"') {
+                inQuotes = !inQuotes;
+            }
+            else if (c == COMMENT_CHAR && !inQuotes) {
+                return value.substring(0, i).strip();
+            }
+        }
+        return value;
+    }
+
+    /**
+     * Strips surrounding double quotes from a value if present.
+     */
+    private String stripQuotes(String value) {
+        if (value.length() >= 2 && value.charAt(0) == '"' && value.charAt(value.length() - 1) == '"') {
+            return value.substring(1, value.length() - 1);
+        }
+        return value;
+    }
+
+    /**
+     * Returns true if the host alias contains wildcard characters.
+     */
+    private boolean isWildcard(String alias) {
+        return alias.chars().anyMatch(c -> WILDCARD_CHARS.indexOf(c) >= 0);
+    }
+
+    /**
+     * Parses a port string into an integer. Returns -1 if the value is not
+     * a valid integer or is outside the allowed range (1-65535).
+     */
+    private int parsePort(String value) {
+        try {
+            int port = Integer.parseInt(value);
+            if (port < MIN_PORT || port > MAX_PORT) {
+                logger.warnv("Port value out of range (1-65535): {0}", value);
+                return -1;
+            }
+            return port;
+        }
+        catch (NumberFormatException e) {
+            logger.warnv("Invalid port value: {0}", value);
+            return -1;
+        }
+    }
+}

--- a/debezium-platform-conductor/src/main/java/io/debezium/platform/environment/host/discovery/SshConfigParser.java
+++ b/debezium-platform-conductor/src/main/java/io/debezium/platform/environment/host/discovery/SshConfigParser.java
@@ -12,6 +12,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.IntStream;
 
@@ -47,6 +48,7 @@ public class SshConfigParser {
     private static final int MAX_PORT = 65535;
     private static final char EQUALS_DELIMITER = '=';
     private static final char COMMENT_CHAR = '#';
+    private static final char QUOTE_CHAR = '"';
     private static final String WILDCARD_CHARS = "*?!";
     private static final String HOST_KEYWORD = "host";
 
@@ -81,8 +83,58 @@ public class SshConfigParser {
 
     /**
      * Core parsing logic that operates on a list of lines.
+     * Streams each raw line through {@link #parseLine(String)} to extract keyword-value
+     * pairs, then groups them into host entries via {@link #buildHostEntries(List)}.
      */
     private List<SshHostEntry> parseLines(List<String> lines) {
+        List<ParsedLine> parsedLines = lines.stream()
+                .map(this::parseLine)
+                .flatMap(Optional::stream)
+                .toList();
+
+        return buildHostEntries(parsedLines);
+    }
+
+    /**
+     * Parses a single raw line into a keyword-value pair.
+     * Returns empty for blank lines, comments, and malformed lines.
+     */
+    private Optional<ParsedLine> parseLine(String rawLine) {
+        String stripped = rawLine.strip();
+
+        if (isBlankOrComment(stripped)) {
+            return Optional.empty();
+        }
+
+        int splitIndex = findDelimiterIndex(stripped);
+        if (splitIndex < 0) {
+            logger.warnv("Malformed line in SSH config (no keyword-value delimiter): {0}", stripped);
+            return Optional.empty();
+        }
+
+        String keyword = stripped.substring(0, splitIndex).strip().toLowerCase();
+        String rawValue = stripped.substring(splitIndex + 1).strip();
+
+        if (!rawValue.isEmpty() && rawValue.charAt(0) == EQUALS_DELIMITER) {
+            rawValue = rawValue.substring(1).strip();
+        }
+
+        if (rawValue.isEmpty()) {
+            logger.warnv("Malformed line in SSH config (empty value): {0}", stripped);
+            return Optional.empty();
+        }
+
+        String value = stripInlineComment(rawValue);
+        value = stripQuotes(value);
+
+        return Optional.of(new ParsedLine(keyword, value));
+    }
+
+    /**
+     * Groups parsed keyword-value lines into host entries, handling wildcards,
+     * duplicates, and invalid ports.
+     */
+    private List<SshHostEntry> buildHostEntries(List<ParsedLine> parsedLines) {
         List<SshHostEntry> hostEntries = new ArrayList<>();
         Set<String> seenAliases = new HashSet<>();
 
@@ -92,44 +144,15 @@ public class SshConfigParser {
         int currentPort = DEFAULT_PORT;
         String currentIdentityFile = null;
 
-        for (String line : lines) {
-            String stripped = line.strip();
-
-            if (isBlankOrComment(stripped)) {
-                continue;
-            }
-
-            String keyword;
-            String value;
-            int splitIndex = findDelimiterIndex(stripped);
-            if (splitIndex < 0) {
-                logger.warnv("Malformed line in SSH config (no keyword-value delimiter): {0}", stripped);
-                continue;
-            }
-
-            keyword = stripped.substring(0, splitIndex).strip().toLowerCase();
-            String rawValue = stripped.substring(splitIndex + 1).strip();
-
-            if (!rawValue.isEmpty() && rawValue.charAt(0) == EQUALS_DELIMITER) {
-                rawValue = rawValue.substring(1).strip();
-            }
-
-            if (rawValue.isEmpty()) {
-                logger.warnv("Malformed line in SSH config (empty value): {0}", stripped);
-                continue;
-            }
-
-            value = stripInlineComment(rawValue);
-            value = stripQuotes(value);
-
-            if (isHostLine(keyword)) {
+        for (ParsedLine parsed : parsedLines) {
+            if (isHostLine(parsed.keyword())) {
                 if (currentAlias != null) {
                     hostEntries.add(new SshHostEntry(currentAlias, currentHostname,
                             currentUser, currentPort, currentIdentityFile));
                 }
 
-                if (isWildcard(value)) {
-                    logger.warnv("Skipping wildcard Host entry: {0}", value);
+                if (isWildcard(parsed.value())) {
+                    logger.warnv("Skipping wildcard Host entry: {0}", parsed.value());
                     currentAlias = null;
                     currentHostname = null;
                     currentUser = null;
@@ -138,8 +161,8 @@ public class SshConfigParser {
                     continue;
                 }
 
-                if (!seenAliases.add(value)) {
-                    logger.warnv("Skipping duplicate Host alias: {0}", value);
+                if (!seenAliases.add(parsed.value())) {
+                    logger.warnv("Skipping duplicate Host alias: {0}", parsed.value());
                     currentAlias = null;
                     currentHostname = null;
                     currentUser = null;
@@ -148,24 +171,24 @@ public class SshConfigParser {
                     continue;
                 }
 
-                currentAlias = value;
+                currentAlias = parsed.value();
                 currentHostname = null;
                 currentUser = null;
                 currentPort = DEFAULT_PORT;
                 currentIdentityFile = null;
             }
             else if (currentAlias != null) {
-                switch (keyword) {
+                switch (parsed.keyword()) {
                     case "hostname":
-                        currentHostname = value;
+                        currentHostname = parsed.value();
                         break;
                     case "user":
-                        currentUser = value;
+                        currentUser = parsed.value();
                         break;
                     case "port":
-                        int port = parsePort(value);
+                        int port = parsePort(parsed.value());
                         if (port < 0) {
-                            logger.warnv("Skipping host entry ''{0}'' due to invalid port: {1}", currentAlias, value);
+                            logger.warnv("Skipping host entry ''{0}'' due to invalid port: {1}", currentAlias, parsed.value());
                             currentAlias = null;
                             currentHostname = null;
                             currentUser = null;
@@ -177,7 +200,7 @@ public class SshConfigParser {
                         }
                         break;
                     case "identityfile":
-                        currentIdentityFile = value;
+                        currentIdentityFile = parsed.value();
                         break;
                     default:
                         break;
@@ -223,7 +246,7 @@ public class SshConfigParser {
         boolean inQuotes = false;
         for (int i = 0; i < value.length(); i++) {
             char c = value.charAt(i);
-            if (c == '"') {
+            if (c == QUOTE_CHAR) {
                 inQuotes = !inQuotes;
             }
             else if (c == COMMENT_CHAR && !inQuotes) {
@@ -237,7 +260,7 @@ public class SshConfigParser {
      * Strips surrounding double quotes from a value if present.
      */
     private String stripQuotes(String value) {
-        if (value.length() >= 2 && value.charAt(0) == '"' && value.charAt(value.length() - 1) == '"') {
+        if (value.length() >= 2 && value.charAt(0) == QUOTE_CHAR && value.charAt(value.length() - 1) == QUOTE_CHAR) {
             return value.substring(1, value.length() - 1);
         }
         return value;
@@ -267,5 +290,11 @@ public class SshConfigParser {
             logger.warnv("Invalid port value: {0}", value);
             return -1;
         }
+    }
+
+    /**
+     * Represents a parsed keyword-value pair from a single SSH config line.
+     */
+    private record ParsedLine(String keyword, String value) {
     }
 }

--- a/debezium-platform-conductor/src/main/java/io/debezium/platform/environment/host/discovery/SshConfigParser.java
+++ b/debezium-platform-conductor/src/main/java/io/debezium/platform/environment/host/discovery/SshConfigParser.java
@@ -137,80 +137,51 @@ public class SshConfigParser {
     private List<SshHostEntry> buildHostEntries(List<ParsedLine> parsedLines) {
         List<SshHostEntry> hostEntries = new ArrayList<>();
         Set<String> seenAliases = new HashSet<>();
-
-        String currentAlias = null;
-        String currentHostname = null;
-        String currentUser = null;
-        int currentPort = DEFAULT_PORT;
-        String currentIdentityFile = null;
+        HostBlock current = new HostBlock();
 
         for (ParsedLine parsed : parsedLines) {
             if (isHostLine(parsed.keyword())) {
-                if (currentAlias != null) {
-                    hostEntries.add(new SshHostEntry(currentAlias, currentHostname,
-                            currentUser, currentPort, currentIdentityFile));
+                if (current.hasAlias()) {
+                    hostEntries.add(current.toSshHostEntry());
                 }
 
                 if (isWildcard(parsed.value())) {
                     logger.warnv("Skipping wildcard Host entry: {0}", parsed.value());
-                    currentAlias = null;
-                    currentHostname = null;
-                    currentUser = null;
-                    currentPort = DEFAULT_PORT;
-                    currentIdentityFile = null;
+                    current.reset();
                     continue;
                 }
 
                 if (!seenAliases.add(parsed.value())) {
                     logger.warnv("Skipping duplicate Host alias: {0}", parsed.value());
-                    currentAlias = null;
-                    currentHostname = null;
-                    currentUser = null;
-                    currentPort = DEFAULT_PORT;
-                    currentIdentityFile = null;
+                    current.reset();
                     continue;
                 }
 
-                currentAlias = parsed.value();
-                currentHostname = null;
-                currentUser = null;
-                currentPort = DEFAULT_PORT;
-                currentIdentityFile = null;
+                current.startNew(parsed.value());
             }
-            else if (currentAlias != null) {
+            else if (current.hasAlias()) {
                 switch (parsed.keyword()) {
-                    case "hostname":
-                        currentHostname = parsed.value();
-                        break;
-                    case "user":
-                        currentUser = parsed.value();
-                        break;
-                    case "port":
+                    case "hostname" -> current.hostname = parsed.value();
+                    case "user" -> current.user = parsed.value();
+                    case "port" -> {
                         int port = parsePort(parsed.value());
                         if (port < 0) {
-                            logger.warnv("Skipping host entry ''{0}'' due to invalid port: {1}", currentAlias, parsed.value());
-                            currentAlias = null;
-                            currentHostname = null;
-                            currentUser = null;
-                            currentPort = DEFAULT_PORT;
-                            currentIdentityFile = null;
+                            logger.warnv("Skipping host entry ''{0}'' due to invalid port: {1}", current.alias, parsed.value());
+                            current.reset();
                         }
                         else {
-                            currentPort = port;
+                            current.port = port;
                         }
-                        break;
-                    case "identityfile":
-                        currentIdentityFile = parsed.value();
-                        break;
-                    default:
-                        break;
+                    }
+                    case "identityfile" -> current.identityFile = parsed.value();
+                    default -> {
+                    }
                 }
             }
         }
 
-        if (currentAlias != null) {
-            hostEntries.add(new SshHostEntry(currentAlias, currentHostname,
-                    currentUser, currentPort, currentIdentityFile));
+        if (current.hasAlias()) {
+            hostEntries.add(current.toSshHostEntry());
         }
 
         return hostEntries;
@@ -296,5 +267,39 @@ public class SshConfigParser {
      * Represents a parsed keyword-value pair from a single SSH config line.
      */
     private record ParsedLine(String keyword, String value) {
+    }
+
+    /**
+     * Mutable accumulator for the fields of a single Host block during parsing.
+     * Encapsulates the reset and conversion logic to avoid repeating field
+     * assignments across the parser.
+     */
+    private static class HostBlock {
+        private String alias;
+        private String hostname;
+        private String user;
+        private int port = DEFAULT_PORT;
+        private String identityFile;
+
+        boolean hasAlias() {
+            return alias != null;
+        }
+
+        void startNew(String alias) {
+            reset();
+            this.alias = alias;
+        }
+
+        void reset() {
+            alias = null;
+            hostname = null;
+            user = null;
+            port = DEFAULT_PORT;
+            identityFile = null;
+        }
+
+        SshHostEntry toSshHostEntry() {
+            return new SshHostEntry(alias, hostname, user, port, identityFile);
+        }
     }
 }

--- a/debezium-platform-conductor/src/main/java/io/debezium/platform/environment/host/discovery/SshHostEntry.java
+++ b/debezium-platform-conductor/src/main/java/io/debezium/platform/environment/host/discovery/SshHostEntry.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.platform.environment.host.discovery;
+
+/**
+ * Holds the parsed connection details for a single Host block from an OpenSSH
+ * {@code ~/.ssh/config} file.
+ *
+ * <p>Instances are produced by {@link SshConfigParser} and consumed by
+ * {@code SshConfigWatcherService} to reconcile host state
+ * in the database.
+ *
+ * <p>All fields reflect values from the SSH config file. {@code hostname},
+ * {@code user}, and {@code identityFile} are nullable — not every SSH config
+ * entry specifies all fields. {@code port} defaults to 22 when absent.
+ */
+public record SshHostEntry(
+        String alias,
+        String hostname,
+        String user,
+        int port,
+        String identityFile) {
+}

--- a/debezium-platform-conductor/src/test/java/io/debezium/platform/environment/host/discovery/SshConfigParserTest.java
+++ b/debezium-platform-conductor/src/test/java/io/debezium/platform/environment/host/discovery/SshConfigParserTest.java
@@ -1,0 +1,268 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.platform.environment.host.discovery;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.file.Path;
+import java.util.List;
+
+import org.jboss.logging.Logger;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class SshConfigParserTest {
+
+    private SshConfigParser parser;
+
+    @BeforeEach
+    void setUp() {
+        parser = new SshConfigParser(Logger.getLogger(SshConfigParser.class));
+    }
+
+    @Test
+    void testStandardWhitespaceDelimiterEntry() throws Exception {
+        List<SshHostEntry> entries = parser.parse(configPath("whitespace-delimiter.config"));
+
+        assertThat(entries).hasSize(1);
+        SshHostEntry entry = entries.get(0);
+        assertThat(entry.alias()).isEqualTo("db-server-1");
+        assertThat(entry.hostname()).isEqualTo("192.168.1.10");
+        assertThat(entry.user()).isEqualTo("ubuntu");
+        assertThat(entry.port()).isEqualTo(22);
+        assertThat(entry.identityFile()).isEqualTo("~/.ssh/db-server-1.key");
+    }
+
+    @Test
+    void testEqualsDelimiterEntry() throws Exception {
+        List<SshHostEntry> entries = parser.parse(configPath("equals-delimiter.config"));
+
+        assertThat(entries).hasSize(1);
+        SshHostEntry entry = entries.get(0);
+        assertThat(entry.hostname()).isEqualTo("192.168.1.20");
+        assertThat(entry.user()).isEqualTo("deploy");
+        assertThat(entry.port()).isEqualTo(22);
+        assertThat(entry.identityFile()).isEqualTo("/home/admin/.ssh/key.pem");
+    }
+
+    @Test
+    void testEqualsWithSpacesDelimiterEntry() throws Exception {
+        List<SshHostEntry> entries = parser.parse(configPath("equals-with-spaces.config"));
+
+        assertThat(entries).hasSize(1);
+        assertThat(entries.get(0).port()).isEqualTo(22);
+    }
+
+    @Test
+    void testInlineCommentStripped() throws Exception {
+        List<SshHostEntry> entries = parser.parse(configPath("inline-comment.config"));
+
+        assertThat(entries).hasSize(1);
+        assertThat(entries.get(0).user()).isEqualTo("deploy");
+    }
+
+    @Test
+    void testQuotedPathWithSpaces() throws Exception {
+        List<SshHostEntry> entries = parser.parse(configPath("quoted-path.config"));
+
+        assertThat(entries).hasSize(1);
+        assertThat(entries.get(0).identityFile()).isEqualTo("/opt/keys/my server key.pem");
+    }
+
+    @Test
+    void testWildcardStarSkipped() throws Exception {
+        List<SshHostEntry> entries = parser.parse(configPath("wildcard-star.config"));
+
+        assertThat(entries).isEmpty();
+    }
+
+    @Test
+    void testWildcardPartialStarSkipped() throws Exception {
+        List<SshHostEntry> entries = parser.parse(configPath("wildcard-partial.config"));
+
+        assertThat(entries).isEmpty();
+    }
+
+    @Test
+    void testWildcardQuestionMarkSkipped() throws Exception {
+        List<SshHostEntry> entries = parser.parse(configPath("wildcard-question.config"));
+
+        assertThat(entries).isEmpty();
+    }
+
+    @Test
+    void testMultipleHostsReturnedInOrder() throws Exception {
+        List<SshHostEntry> entries = parser.parse(configPath("multiple-hosts.config"));
+
+        assertThat(entries).hasSize(3);
+        assertThat(entries.get(0).alias()).isEqualTo("alpha");
+        assertThat(entries.get(1).alias()).isEqualTo("beta");
+        assertThat(entries.get(2).alias()).isEqualTo("gamma");
+    }
+
+    @Test
+    void testMalformedLineSkippedGracefully() throws Exception {
+        List<SshHostEntry> entries = parser.parse(configPath("malformed-line.config"));
+
+        assertThat(entries).hasSize(1);
+        SshHostEntry entry = entries.get(0);
+        assertThat(entry.hostname()).isEqualTo("192.168.1.10");
+        assertThat(entry.user()).isEqualTo("ubuntu");
+    }
+
+    @Test
+    void testCaseInsensitiveKeywordHost() throws Exception {
+        List<SshHostEntry> entries = parser.parse(configPath("case-insensitive-host.config"));
+
+        assertThat(entries).hasSize(1);
+        assertThat(entries.get(0).alias()).isEqualTo("db-server-1");
+    }
+
+    @Test
+    void testCaseInsensitiveKeywordHostname() throws Exception {
+        List<SshHostEntry> entries = parser.parse(configPath("case-insensitive-hostname.config"));
+
+        assertThat(entries).hasSize(1);
+        assertThat(entries.get(0).hostname()).isEqualTo("192.168.1.10");
+    }
+
+    @Test
+    void testCaseInsensitiveKeywordUser() throws Exception {
+        List<SshHostEntry> entries = parser.parse(configPath("case-insensitive-user.config"));
+
+        assertThat(entries).hasSize(1);
+        assertThat(entries.get(0).user()).isEqualTo("ubuntu");
+    }
+
+    @Test
+    void testDefaultPortWhenAbsent() throws Exception {
+        List<SshHostEntry> entries = parser.parse(configPath("default-port.config"));
+
+        assertThat(entries).hasSize(1);
+        assertThat(entries.get(0).port()).isEqualTo(22);
+    }
+
+    @Test
+    void testInvalidPortSkipsEntry() throws Exception {
+        List<SshHostEntry> entries = parser.parse(configPath("invalid-port.config"));
+
+        assertThat(entries).isEmpty();
+    }
+
+    @Test
+    void testPortOutOfRangeSkipsEntry() throws Exception {
+        List<SshHostEntry> entries = parser.parse(configPath("port-out-of-range.config"));
+
+        assertThat(entries).isEmpty();
+    }
+
+    @Test
+    void testEmptyContentReturnsEmptyList() throws Exception {
+        List<SshHostEntry> entries = parser.parseContent("");
+
+        assertThat(entries).isNotNull().isEmpty();
+    }
+
+    @Test
+    void testOnlyCommentsReturnsEmptyList() throws Exception {
+        List<SshHostEntry> entries = parser.parse(configPath("only-comments.config"));
+
+        assertThat(entries).isEmpty();
+    }
+
+    @Test
+    void testUnknownKeywordsIgnored() throws Exception {
+        List<SshHostEntry> entries = parser.parse(configPath("unknown-keywords.config"));
+
+        assertThat(entries).hasSize(2);
+        assertThat(entries.get(0).hostname()).isEqualTo("10.0.0.1");
+        assertThat(entries.get(0).user()).isEqualTo("ubuntu");
+    }
+
+    @Test
+    void testHostWithOnlyAlias() throws Exception {
+        List<SshHostEntry> entries = parser.parse(configPath("alias-only.config"));
+
+        assertThat(entries).hasSize(1);
+        SshHostEntry entry = entries.get(0);
+        assertThat(entry.alias()).isEqualTo("minimal-server");
+        assertThat(entry.hostname()).isNull();
+        assertThat(entry.user()).isNull();
+        assertThat(entry.port()).isEqualTo(22);
+        assertThat(entry.identityFile()).isNull();
+    }
+
+    @Test
+    void testMixedWildcardAndRealHosts() throws Exception {
+        List<SshHostEntry> entries = parser.parse(configPath("mixed-wildcard.config"));
+
+        assertThat(entries).hasSize(1);
+        assertThat(entries.get(0).alias()).isEqualTo("real-server");
+    }
+
+    @Test
+    void testDuplicateAliasSkipped() throws Exception {
+        List<SshHostEntry> entries = parser.parse(configPath("duplicate-alias.config"));
+
+        assertThat(entries).hasSize(1);
+        assertThat(entries.get(0).alias()).isEqualTo("db-server-1");
+        assertThat(entries.get(0).hostname()).isEqualTo("10.0.0.1");
+    }
+
+    @Test
+    void testFullExampleFromSpec() throws Exception {
+        List<SshHostEntry> entries = parser.parse(configPath("full-example.config"));
+
+        assertThat(entries).hasSize(3);
+
+        SshHostEntry e1 = entries.get(0);
+        assertThat(e1.alias()).isEqualTo("db-server-1");
+        assertThat(e1.hostname()).isEqualTo("192.168.1.10");
+        assertThat(e1.user()).isEqualTo("ubuntu");
+        assertThat(e1.port()).isEqualTo(22);
+        assertThat(e1.identityFile()).isEqualTo("~/.ssh/db-server-1.key");
+
+        SshHostEntry e2 = entries.get(1);
+        assertThat(e2.alias()).isEqualTo("db-server-2");
+        assertThat(e2.hostname()).isEqualTo("192.168.1.20");
+        assertThat(e2.user()).isEqualTo("deploy");
+        assertThat(e2.port()).isEqualTo(2222);
+        assertThat(e2.identityFile()).isEqualTo("/home/admin/.ssh/db-server-2.key");
+
+        SshHostEntry e3 = entries.get(2);
+        assertThat(e3.alias()).isEqualTo("db-server-3");
+        assertThat(e3.hostname()).isEqualTo("192.168.1.30");
+        assertThat(e3.user()).isEqualTo("deploy");
+        assertThat(e3.port()).isEqualTo(22);
+        assertThat(e3.identityFile()).isEqualTo("/opt/keys/db server 3.key");
+    }
+
+    @Test
+    void testParsePath() throws Exception {
+        List<SshHostEntry> entries = parser.parse(configPath("valid-multi-host.config"));
+
+        assertThat(entries).hasSize(2);
+
+        SshHostEntry e1 = entries.get(0);
+        assertThat(e1.alias()).isEqualTo("db-server-1");
+        assertThat(e1.hostname()).isEqualTo("192.168.1.10");
+        assertThat(e1.user()).isEqualTo("ubuntu");
+        assertThat(e1.port()).isEqualTo(22);
+        assertThat(e1.identityFile()).isEqualTo("~/.ssh/db-server-1.key");
+
+        SshHostEntry e2 = entries.get(1);
+        assertThat(e2.alias()).isEqualTo("db-server-2");
+        assertThat(e2.hostname()).isEqualTo("192.168.1.20");
+        assertThat(e2.user()).isEqualTo("deploy");
+        assertThat(e2.port()).isEqualTo(2222);
+        assertThat(e2.identityFile()).isEqualTo("~/.ssh/db-server-2.key");
+    }
+
+    private Path configPath(String filename) throws Exception {
+        return Path.of(getClass().getClassLoader()
+                .getResource("ssh-config/" + filename).toURI());
+    }
+}

--- a/debezium-platform-conductor/src/test/resources/ssh-config/alias-only.config
+++ b/debezium-platform-conductor/src/test/resources/ssh-config/alias-only.config
@@ -1,0 +1,1 @@
+Host minimal-server

--- a/debezium-platform-conductor/src/test/resources/ssh-config/case-insensitive-host.config
+++ b/debezium-platform-conductor/src/test/resources/ssh-config/case-insensitive-host.config
@@ -1,0 +1,2 @@
+HOST db-server-1
+    HostName 10.0.0.1

--- a/debezium-platform-conductor/src/test/resources/ssh-config/case-insensitive-hostname.config
+++ b/debezium-platform-conductor/src/test/resources/ssh-config/case-insensitive-hostname.config
@@ -1,0 +1,2 @@
+Host db-server-1
+    HOSTNAME 192.168.1.10

--- a/debezium-platform-conductor/src/test/resources/ssh-config/case-insensitive-user.config
+++ b/debezium-platform-conductor/src/test/resources/ssh-config/case-insensitive-user.config
@@ -1,0 +1,2 @@
+Host db-server-1
+    USER ubuntu

--- a/debezium-platform-conductor/src/test/resources/ssh-config/default-port.config
+++ b/debezium-platform-conductor/src/test/resources/ssh-config/default-port.config
@@ -1,0 +1,2 @@
+Host db-server-1
+    HostName 10.0.0.1

--- a/debezium-platform-conductor/src/test/resources/ssh-config/duplicate-alias.config
+++ b/debezium-platform-conductor/src/test/resources/ssh-config/duplicate-alias.config
@@ -1,0 +1,5 @@
+Host db-server-1
+    HostName 10.0.0.1
+
+Host db-server-1
+    HostName 10.0.0.2

--- a/debezium-platform-conductor/src/test/resources/ssh-config/equals-delimiter.config
+++ b/debezium-platform-conductor/src/test/resources/ssh-config/equals-delimiter.config
@@ -1,0 +1,5 @@
+Host db-server-2
+    HostName=192.168.1.20
+    User=deploy
+    Port=22
+    IdentityFile=/home/admin/.ssh/key.pem

--- a/debezium-platform-conductor/src/test/resources/ssh-config/equals-with-spaces.config
+++ b/debezium-platform-conductor/src/test/resources/ssh-config/equals-with-spaces.config
@@ -1,0 +1,2 @@
+Host db-server-3
+    Port = 22

--- a/debezium-platform-conductor/src/test/resources/ssh-config/full-example.config
+++ b/debezium-platform-conductor/src/test/resources/ssh-config/full-example.config
@@ -1,0 +1,20 @@
+# Global settings
+Host *
+    ServerAliveInterval 60
+
+Host db-server-1
+    HostName 192.168.1.10
+    User ubuntu
+    Port 22
+    IdentityFile ~/.ssh/db-server-1.key
+
+Host db-server-2
+    HostName=192.168.1.20
+    User=deploy
+    Port=2222
+    IdentityFile=/home/admin/.ssh/db-server-2.key
+
+Host db-server-3
+    HostName 192.168.1.30
+    User deploy # production server
+    IdentityFile "/opt/keys/db server 3.key"

--- a/debezium-platform-conductor/src/test/resources/ssh-config/inline-comment.config
+++ b/debezium-platform-conductor/src/test/resources/ssh-config/inline-comment.config
@@ -1,0 +1,2 @@
+Host db-server-1
+    User deploy # production

--- a/debezium-platform-conductor/src/test/resources/ssh-config/invalid-port.config
+++ b/debezium-platform-conductor/src/test/resources/ssh-config/invalid-port.config
@@ -1,0 +1,2 @@
+Host db-server-1
+    Port notanumber

--- a/debezium-platform-conductor/src/test/resources/ssh-config/malformed-line.config
+++ b/debezium-platform-conductor/src/test/resources/ssh-config/malformed-line.config
@@ -1,0 +1,4 @@
+Host db-server-1
+    HostName 192.168.1.10
+    ThisIsCompletelyWrong!!!
+    User ubuntu

--- a/debezium-platform-conductor/src/test/resources/ssh-config/mixed-wildcard.config
+++ b/debezium-platform-conductor/src/test/resources/ssh-config/mixed-wildcard.config
@@ -1,0 +1,8 @@
+Host *
+    ServerAliveInterval 60
+
+Host real-server
+    HostName 10.0.0.1
+
+Host db-?
+    HostName 10.0.0.2

--- a/debezium-platform-conductor/src/test/resources/ssh-config/multiple-hosts.config
+++ b/debezium-platform-conductor/src/test/resources/ssh-config/multiple-hosts.config
@@ -1,0 +1,8 @@
+Host alpha
+    HostName 10.0.0.1
+
+Host beta
+    HostName 10.0.0.2
+
+Host gamma
+    HostName 10.0.0.3

--- a/debezium-platform-conductor/src/test/resources/ssh-config/only-comments.config
+++ b/debezium-platform-conductor/src/test/resources/ssh-config/only-comments.config
@@ -1,0 +1,2 @@
+# This is a comment
+# Another comment

--- a/debezium-platform-conductor/src/test/resources/ssh-config/port-out-of-range.config
+++ b/debezium-platform-conductor/src/test/resources/ssh-config/port-out-of-range.config
@@ -1,0 +1,2 @@
+Host db-server-1
+    Port 99999

--- a/debezium-platform-conductor/src/test/resources/ssh-config/quoted-path.config
+++ b/debezium-platform-conductor/src/test/resources/ssh-config/quoted-path.config
@@ -1,0 +1,2 @@
+Host db-server-1
+    IdentityFile "/opt/keys/my server key.pem"

--- a/debezium-platform-conductor/src/test/resources/ssh-config/unknown-keywords.config
+++ b/debezium-platform-conductor/src/test/resources/ssh-config/unknown-keywords.config
@@ -1,0 +1,10 @@
+Host db-server-1
+    HostName 10.0.0.1
+    StrictHostKeyChecking no
+    ServerAliveInterval 60
+    ForwardAgent yes
+    User ubuntu
+
+Host db-server-2
+     HostName 10.0.0.2
+     User deploy

--- a/debezium-platform-conductor/src/test/resources/ssh-config/valid-multi-host.config
+++ b/debezium-platform-conductor/src/test/resources/ssh-config/valid-multi-host.config
@@ -1,0 +1,15 @@
+# Test fixture — valid multi-host SSH config
+Host *
+    ServerAliveInterval 60
+
+Host db-server-1
+    HostName 192.168.1.10
+    User ubuntu
+    Port 22
+    IdentityFile ~/.ssh/db-server-1.key
+
+Host db-server-2
+    HostName 192.168.1.20
+    User deploy
+    Port 2222
+    IdentityFile ~/.ssh/db-server-2.key

--- a/debezium-platform-conductor/src/test/resources/ssh-config/whitespace-delimiter.config
+++ b/debezium-platform-conductor/src/test/resources/ssh-config/whitespace-delimiter.config
@@ -1,0 +1,5 @@
+Host db-server-1
+    HostName 192.168.1.10
+    User ubuntu
+    Port 22
+    IdentityFile ~/.ssh/db-server-1.key

--- a/debezium-platform-conductor/src/test/resources/ssh-config/wildcard-partial.config
+++ b/debezium-platform-conductor/src/test/resources/ssh-config/wildcard-partial.config
@@ -1,0 +1,2 @@
+Host db-*
+    HostName 10.0.0.1

--- a/debezium-platform-conductor/src/test/resources/ssh-config/wildcard-question.config
+++ b/debezium-platform-conductor/src/test/resources/ssh-config/wildcard-question.config
@@ -1,0 +1,2 @@
+Host db-?
+    HostName 10.0.0.1

--- a/debezium-platform-conductor/src/test/resources/ssh-config/wildcard-star.config
+++ b/debezium-platform-conductor/src/test/resources/ssh-config/wildcard-star.config
@@ -1,0 +1,2 @@
+Host *
+    ServerAliveInterval 60


### PR DESCRIPTION
Fixes debezium/dbz#2088

## Description

Adds `SshConfigParser`, a stateless `@ApplicationScoped` bean that reads anSSH config file and returns a list of `SshHostEntry` records with the connection details (alias, hostname, user, port, identity file).

The parser handles the standard `ssh_config(5)` format: both whitespace and `=` delimiters, inline comments, quoted paths with spaces, case-insensitive keywords, and wildcard entries (`Host *`, `Host db-*`) which are skipped
since they don't represent actual hosts.

No existing files were modified. No new dependencies were added - parsing uses only `java.nio.file` and standard `String` methods.

The `SshConfigWatcherService` ([next sub-issue](https://github.com/debezium/dbz/issues/2090)) will `@Inject` this parser and call `parse(Path)` whenever the SSH config file changes on disk.

24 unit tests cover all parsing rules, including edge cases (malformed lines, out-of-range ports, duplicate aliases, alias-only entries).

## PR Checklist

- [X] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [X] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [X] One feature/change per PR unless tightly coupled
- [X] Do a rebase on upstream `main`
