### PR TITLE
debezium/dbz#2216 fix\(stage\): fix legibility of default values in d…

### DIFF
--- a/debezium-platform-stage/src/components/AdditionalPropertiesRows.tsx
+++ b/debezium-platform-stage/src/components/AdditionalPropertiesRows.tsx
@@ -77,7 +77,7 @@ const AdditionalPropertiesRows: React.FunctionComponent<AdditionalPropertiesRows
                       isRequired={!viewMode}
                     >
                       <TextInput
-                        readOnlyVariant={viewMode ? "default" : undefined}
+                        readOnlyVariant={viewMode ? "plain" : undefined}
                         isRequired={!viewMode}
                         type="text"
                         placeholder={t("connection:additionalProperties.keyPlaceholder")}
@@ -114,7 +114,7 @@ const AdditionalPropertiesRows: React.FunctionComponent<AdditionalPropertiesRows
                     {row.valueKind === "string" && (
                       <FormGroup fieldId={`${fieldIdPrefix}-value-input-${rowId}`} isRequired={!viewMode}>
                         <TextInput
-                          readOnlyVariant={viewMode ? "default" : undefined}
+                          readOnlyVariant={viewMode ? "plain" : undefined}
                           isRequired={!viewMode}
                           type="text"
                           id={`${fieldIdPrefix}-value-input-${rowId}`}
@@ -153,7 +153,7 @@ const AdditionalPropertiesRows: React.FunctionComponent<AdditionalPropertiesRows
                     {row.valueKind === "integer" && (
                       <FormGroup fieldId={`${fieldIdPrefix}-value-input-${rowId}`} isRequired={!viewMode}>
                         <TextInput
-                          readOnlyVariant={viewMode ? "default" : undefined}
+                          readOnlyVariant={viewMode ? "plain" : undefined}
                           isRequired={!viewMode}
                           type="text"
                           inputMode="numeric"

--- a/debezium-platform-stage/src/components/SchemaReviewValue.css
+++ b/debezium-platform-stage/src/components/SchemaReviewValue.css
@@ -8,9 +8,13 @@
 .connector-schema-review__value--default {
   font-size: var(--pf-v5-global--FontSize--md, 1rem);
   font-weight: var(--pf-v5-global--FontWeight--normal);
-  color: var(--pf-v5-global--Color--100, #151515);
+  color: var(--pf-t--global--text--color--regular, var(--pf-v5-global--Color--100, #151515));
   display: inline-block;
   word-break: break-word;
+}
+
+.pf-v6-theme-dark .connector-schema-review__value--default {
+  color: var(--pf-t--global--text--color--regular, #f0f0f0);
 }
 
 .connector-schema-review__state-badge {

--- a/debezium-platform-stage/src/components/SchemaReviewView.css
+++ b/debezium-platform-stage/src/components/SchemaReviewView.css
@@ -1,7 +1,7 @@
 
 
 .connector-schema-review__value--empty {
-  color: var(--pf-v5-global--Color--200, #6a6e73);
+  color: var(--pf-t--global--text--color--subtle, var(--pf-v5-global--Color--200, #6a6e73));
   font-weight: var(--pf-v5-global--FontWeight--normal);
 }
 
@@ -19,6 +19,10 @@
   word-break: break-word;
   box-decoration-break: clone;
   -webkit-box-decoration-break: clone;
+}
+
+.pf-v6-theme-dark .connector-schema-review__value--set {
+  color: var(--pf-t--global--color--link--default, #ad9fcb);
 }
 
 .connector-schema-review__term {
@@ -41,7 +45,7 @@
 
 .connector-schema-review__desc {
   margin-bottom: 0;
-  color: var(--pf-v5-global--Color--200);
+  color: var(--pf-t--global--text--color--subtle, var(--pf-v5-global--Color--200, #6a6e73));
 }
 
 .connector-schema-review__dl {


### PR DESCRIPTION
… and destination details

<!-- Make sure all your commits are signed before submitting your pull request -->
<!-- Run `git commit -s` to sign off your commits to satisfy the DCO check -->
<!-- Ensure your commit messages start with your GitHub issue, e.g., debezium/dbz#<issue_number> -->
Fixes debezium/dbz#2216

## Description
<!-- Briefly describe your changes here. -->

This PR resolves issue [#2216](https://github.com/debezium/dbz/issues/2216) where default value text in view details for source/destination connectors remains dark and unreadable under the dark theme.

### Causes & Fixes:
1. **Set Configuration Values**: Legibility was compromised by a hardcoded dark purple color (`#5E406E`) on `.connector-schema-review__value--set` inside `SchemaReviewView.css`. 
   - **Fix**: Added a dark theme override (`.pf-v6-theme-dark .connector-schema-review__value--set`) referencing PatternFly's default link color (`var(--pf-t--global--color--link--default)`). Also modernized subtle text properties to use `var(--pf-t--global--text--color--subtle)`.
2. **Read-only Additional Properties**: Inputs for properties in view-mode retained a dark border and font color because of `readOnlyVariant="default"`.
   - **Fix**: Changed `readOnlyVariant` to `"plain"` inside `AdditionalPropertiesRows.tsx` to align it with other read-only view elements, allowing the font color to naturally scale and adapt to dark theme backgrounds.

## PR Checklist
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`

## Verification
- Checked that typechecking compiles successfully (`npm run type-check`).
- Ran all unit tests locally (`npm run test -- --run`): all 360 tests in 64 test suites passed.
