### PR TITLE
debezium/dbz#2136 Reuse RetryingRunnable for the OutboxParentEventConsumer errors

### DIFF
--- a/debezium-platform-conductor/src/main/java/io/debezium/platform/environment/watcher/consumers/OutboxParentEventConsumer.java
+++ b/debezium-platform-conductor/src/main/java/io/debezium/platform/environment/watcher/consumers/OutboxParentEventConsumer.java
@@ -5,6 +5,7 @@
  */
 package io.debezium.platform.environment.watcher.consumers;
 
+import java.time.Duration;
 import java.util.function.Consumer;
 
 import jakarta.enterprise.context.Dependent;
@@ -18,6 +19,8 @@ import org.slf4j.LoggerFactory;
 import io.debezium.engine.ChangeEvent;
 import io.debezium.platform.environment.watcher.config.OutboxConfigGroup;
 import io.debezium.platform.environment.watcher.config.WatcherConfigGroup;
+import io.debezium.util.DelayStrategy;
+import io.debezium.util.RetryingRunnable;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 
 /**
@@ -62,58 +65,24 @@ public final class OutboxParentEventConsumer implements Consumer<ChangeEvent<Sou
     }
 
     private void consumeWithRetry(EnvironmentEventConsumer<?> consumer, EventContext context) {
-
-        for (int attempt = 1; attempt <= maxRetries + 1; attempt++) {
-            try {
-                consumer.consume(context.aggregateType(), context.eventType(),
-                        Long.valueOf(context.aggregateId()), context.payload());
-                return;
-            }
-            catch (Exception e) {
-                if (isRetriable(e) && attempt <= maxRetries) {
-                    var delay = backoffDelay(attempt);
-                    LOGGER.warn("Retriable error processing {} event for aggregate {} (#{}),"
-                            + " attempt {}/{}, retrying in {}ms",
-                            context.eventType(), context.aggregateType(), context.aggregateId(),
-                            attempt, maxRetries, delay, e);
-                    if (!sleep(delay)) {
-                        return;
-                    }
-                }
-                else {
-                    LOGGER.error("Failed to process {} event for aggregate {} (#{}){}. Skipping event.",
-                            context.eventType(), context.aggregateType(), context.aggregateId(),
-                            attempt > 1 ? " after %d retries".formatted(attempt - 1) : "",
-                            e);
-                    consumer.onError(context.aggregateId, context.aggregateType(), context.eventType(), e);
-                    return;
-                }
-            }
-        }
-    }
-
-    private long backoffDelay(int attempt) {
-        return (long) Math.pow(2, attempt - 1) * 1000;
-    }
-
-    private boolean sleep(long millis) {
         try {
-            Thread.sleep(millis);
-            return true;
+            RetryingRunnable.<RuntimeException> builder()
+                    .retries(maxRetries)
+                    .doRun(() -> consumer.consume(context.aggregateType(), context.eventType(),
+                            Long.valueOf(context.aggregateId()), context.payload()))
+                    .delayStrategy(DelayStrategy.exponential(Duration.ofSeconds(1), Duration.ofSeconds(8)))
+                    .retriableExceptions(KubernetesClientException.class)
+                    .build()
+                    .run();
         }
         catch (InterruptedException e) {
             Thread.currentThread().interrupt();
-            return false;
         }
-    }
-
-    private boolean isRetriable(Throwable throwable) {
-        for (var current = throwable; current != null; current = current.getCause()) {
-            if (current instanceof KubernetesClientException) {
-                return true;
-            }
+        catch (Exception e) {
+            LOGGER.error("Failed to process {} event for aggregate {} (#{}). Skipping event.",
+                    context.eventType(), context.aggregateType(), context.aggregateId(), e);
+            consumer.onError(context.aggregateId(), context.aggregateType(), context.eventType(), e);
         }
-        return false;
     }
 
     private record EventContext(String aggregateType, String aggregateId, String eventType, String payload) {

--- a/debezium-platform-conductor/src/test/java/io/debezium/platform/environment/watcher/consumers/OutboxParentEventConsumerTest.java
+++ b/debezium-platform-conductor/src/test/java/io/debezium/platform/environment/watcher/consumers/OutboxParentEventConsumerTest.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.platform.environment.watcher.consumers;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.function.Consumer;
+
+import jakarta.enterprise.inject.Instance;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import io.debezium.doc.FixFor;
+import io.debezium.engine.ChangeEvent;
+import io.debezium.platform.environment.watcher.config.OutboxConfigGroup;
+import io.debezium.platform.environment.watcher.config.WatcherConfigGroup;
+import io.fabric8.kubernetes.client.KubernetesClientException;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class OutboxParentEventConsumerTest {
+
+    private static final Schema EVENT_SCHEMA = SchemaBuilder.struct()
+            .field("aggregatetype", Schema.STRING_SCHEMA)
+            .field("aggregateid", Schema.STRING_SCHEMA)
+            .field("type", Schema.STRING_SCHEMA)
+            .field("payload", Schema.STRING_SCHEMA)
+            .build();
+
+    @Mock
+    OutboxConfigGroup outbox;
+
+    @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+    WatcherConfigGroup watcherConfig;
+
+    @Mock
+    EnvironmentEventConsumer<?> eventConsumer;
+
+    @SuppressWarnings("unchecked")
+    Instance<EnvironmentEventConsumer<?>> eventConsumers = mock(Instance.class);
+
+    OutboxParentEventConsumer consumer;
+
+    @BeforeEach
+    void setUp() {
+        when(outbox.aggregateColumn()).thenReturn("aggregatetype");
+        when(outbox.aggregateIdColumn()).thenReturn("aggregateid");
+        when(outbox.typeColumn()).thenReturn("type");
+        when(watcherConfig.retry().maxRetries()).thenReturn(3);
+        doAnswer(invocation -> {
+            @SuppressWarnings("unchecked")
+            Consumer<EnvironmentEventConsumer<?>> action = invocation.getArgument(0);
+            action.accept(eventConsumer);
+            return null;
+        }).when(eventConsumers).forEach(any());
+
+        consumer = new OutboxParentEventConsumer(outbox, watcherConfig, eventConsumers);
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2136")
+    void successfulEventConsumption() {
+        consumer.accept(createEvent("pipeline", "42", "CREATE", "{\"name\":\"test\"}"));
+
+        verify(eventConsumer, times(1)).consume(eq("pipeline"), eq("CREATE"), eq(42L), eq("{\"name\":\"test\"}"));
+        verify(eventConsumer, never()).onError(anyString(), anyString(), anyString(), any());
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2136")
+    void retriableExceptionRetriesAndSucceeds() {
+        doThrow(new KubernetesClientException("transient"))
+                .doNothing()
+                .when(eventConsumer).consume(anyString(), anyString(), anyLong(), anyString());
+
+        consumer.accept(createEvent("pipeline", "42", "CREATE", "{}"));
+
+        verify(eventConsumer, times(2)).consume(eq("pipeline"), eq("CREATE"), eq(42L), eq("{}"));
+        verify(eventConsumer, never()).onError(anyString(), anyString(), anyString(), any());
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2136")
+    void retriableExceptionExhaustsRetries() {
+        doThrow(new KubernetesClientException("persistent"))
+                .when(eventConsumer).consume(anyString(), anyString(), anyLong(), anyString());
+
+        consumer.accept(createEvent("pipeline", "42", "CREATE", "{}"));
+
+        verify(eventConsumer, times(4)).consume(eq("pipeline"), eq("CREATE"), eq(42L), eq("{}"));
+        verify(eventConsumer).onError(eq("42"), eq("pipeline"), eq("CREATE"), any(KubernetesClientException.class));
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2136")
+    void nonRetriableExceptionSkipsImmediately() {
+        doThrow(new NullPointerException("non-retriable"))
+                .when(eventConsumer).consume(anyString(), anyString(), anyLong(), anyString());
+
+        consumer.accept(createEvent("pipeline", "42", "CREATE", "{}"));
+
+        verify(eventConsumer, times(1)).consume(eq("pipeline"), eq("CREATE"), eq(42L), eq("{}"));
+        verify(eventConsumer).onError(eq("42"), eq("pipeline"), eq("CREATE"), any(NullPointerException.class));
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2136")
+    void nullValueIsIgnored() {
+        @SuppressWarnings("unchecked")
+        ChangeEvent<SourceRecord, SourceRecord> event = mock(ChangeEvent.class);
+        SourceRecord sourceRecord = mock(SourceRecord.class);
+        when(event.value()).thenReturn(sourceRecord);
+        when(sourceRecord.value()).thenReturn(null);
+
+        consumer.accept(event);
+
+        verify(eventConsumer, never()).consume(anyString(), anyString(), anyLong(), anyString());
+    }
+
+    @SuppressWarnings("unchecked")
+    private ChangeEvent<SourceRecord, SourceRecord> createEvent(String aggregateType, String aggregateId,
+                                                                String eventType, String payload) {
+        Struct struct = new Struct(EVENT_SCHEMA)
+                .put("aggregatetype", aggregateType)
+                .put("aggregateid", aggregateId)
+                .put("type", eventType)
+                .put("payload", payload);
+
+        ChangeEvent<SourceRecord, SourceRecord> event = mock(ChangeEvent.class);
+        SourceRecord sourceRecord = mock(SourceRecord.class);
+        when(event.value()).thenReturn(sourceRecord);
+        when(sourceRecord.value()).thenReturn(struct);
+        return event;
+    }
+}


### PR DESCRIPTION
<!-- Make sure all your commits are signed before submitting your pull request -->
<!-- Run `git commit -s` to sign off your commits to satisfy the DCO check -->
<!-- Ensure your commit messages start with your GitHub issue, e.g., debezium/dbz#<issue_number> -->
Fixes debezium/dbz#2136

## Description
This pull request refactors the retry logic in the `OutboxParentEventConsumer` class to use a centralized utility and adds comprehensive unit tests for event consumption and error handling. The changes improve maintainability, reliability, and test coverage of the event consumer.

## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [X] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [X] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [X] One feature/change per PR unless tightly coupled
- [X] Do a rebase on upstream `main`
