### PR TITLE
debezium/dbz#2250 Add the description field to the connection form, view and edit pages

### DIFF
--- a/debezium-platform-stage/public/locales/en/connection.json
+++ b/debezium-platform-stage/public/locales/en/connection.json
@@ -27,6 +27,10 @@
         "description": "Edit the {{val}} connector details using the below form.",
         "saveChanges": "Save changes"
     },
+    "form": {
+        "descriptionField": "Description",
+        "descriptionFieldHelperText": "Add a one liner to describe this connection or what it is used for."
+    },
     "link":{
         "selectConnection": "Select a connection",
         "connectionFieldLabel": "Connection to the {{val}}",

--- a/debezium-platform-stage/public/locales/it/connection.json
+++ b/debezium-platform-stage/public/locales/it/connection.json
@@ -27,6 +27,10 @@
         "description": "Modifica i dettagli della connessione {{val}} utilizzando il modulo sottostante.",
         "saveChanges": "Salva modifiche"
     },
+    "form": {
+        "descriptionField": "Descrizione",
+        "descriptionFieldHelperText": "Aggiungi una breve descrizione di questa connessione o del suo utilizzo."
+    },
     "link":{
         "selectConnection": "Seleziona una connessione",
         "connectionFieldLabel": "Connessione a {{val}}",

--- a/debezium-platform-stage/src/pages/Connection/CreateConnection.test.tsx
+++ b/debezium-platform-stage/src/pages/Connection/CreateConnection.test.tsx
@@ -1,0 +1,175 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { fireEvent, screen, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { useQuery } from "react-query";
+import { createPost } from "src/apis";
+import { CreateConnection } from "./CreateConnection";
+import { render } from "../../__test__/unit/test-utils";
+
+vi.mock("react-router-dom", async (importOriginal) => {
+  const mod = await importOriginal<typeof import("react-router-dom")>();
+  return {
+    ...mod,
+    useNavigate: () => vi.fn(),
+    useLocation: () => ({ state: { connectionType: "source" } }),
+    useParams: () => ({ connectionId: "postgres" }),
+  };
+});
+
+vi.mock("react-query", async (importOriginal) => {
+  const mod = await importOriginal<typeof import("react-query")>();
+  return { ...mod, useQuery: vi.fn() };
+});
+
+vi.mock("src/apis", async (importOriginal) => {
+  const mod = await importOriginal<typeof import("src/apis")>();
+  return { ...mod, createPost: vi.fn(), fetchData: vi.fn() };
+});
+
+vi.mock("../../appLayout/AppContext", () => ({
+  useData: () => ({
+    darkMode: false,
+    navigationCollapsed: false,
+    setDarkMode: vi.fn(),
+    updateNavigationCollapsed: vi.fn(),
+  }),
+}));
+
+/** Payload passed to the POST that creates the connection. */
+const lastCreatePayload = () => {
+  const call = vi
+    .mocked(createPost)
+    .mock.calls.find(([url]) => String(url).endsWith("/api/connections"));
+  return call?.[1] as Record<string, unknown> | undefined;
+};
+
+/** Matches the mocked `connectionId` of "postgres", so `selectedSchema` resolves. */
+const POSTGRES_SCHEMA = [
+  {
+    type: "POSTGRES",
+    schema: {
+      type: "object",
+      title: "PostgreSQL",
+      description: "PostgreSQL connection properties",
+      required: ["hostname"],
+      additionalProperties: { type: "string" },
+      properties: { hostname: { type: "string", title: "Hostname" } },
+    },
+  },
+];
+
+describe("CreateConnection description field", () => {
+  /** `connectionsSchema` drives whether the form takes the schema-backed path. */
+  const withSchemas = (schemas: unknown) =>
+    vi.mocked(useQuery).mockImplementation(
+      ((key: unknown) =>
+        key === "connectionsSchema"
+          ? { data: schemas, error: null, isLoading: false }
+          : { data: [], error: null, isLoading: false }) as any,
+    );
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Default: no schema for this type, so the form renders the plain
+    // name + description + additional-properties path and submits directly.
+    withSchemas([]);
+    vi.mocked(createPost).mockResolvedValue({
+      data: { id: 1, name: "conn", valid: true },
+      error: undefined,
+    } as any);
+  });
+
+  // The name FormGroup is `isRequired`, so its label carries a required marker
+  // and is not an exact text match; target the inputs by id, as the Cypress
+  // specs for this same form already do.
+  const input = (id: string) => document.getElementById(id) as HTMLInputElement;
+
+  const submit = () =>
+    fireEvent.submit(document.getElementById("create-connection-form")!);
+
+  it("renders an optional description input", () => {
+    render(<CreateConnection />);
+    const description = screen.getByLabelText("Description");
+    expect(description).toBeInTheDocument();
+    expect(description).not.toBeRequired();
+    expect(description).toHaveValue("");
+  });
+
+  it("sends the entered description in the create payload", async () => {
+    render(<CreateConnection />);
+    fireEvent.change(input("connection-name"), {
+      target: { value: "orders-db" },
+    });
+    fireEvent.change(screen.getByLabelText("Description"), {
+      target: { value: "Primary OLTP database" },
+    });
+    submit();
+
+    await waitFor(() => expect(lastCreatePayload()).toBeDefined());
+    expect(lastCreatePayload()).toMatchObject({
+      name: "orders-db",
+      description: "Primary OLTP database",
+    });
+  });
+
+  it("still submits when the description is left empty", async () => {
+    render(<CreateConnection />);
+    fireEvent.change(input("connection-name"), {
+      target: { value: "orders-db" },
+    });
+    submit();
+
+    await waitFor(() => expect(lastCreatePayload()).toBeDefined());
+    expect(lastCreatePayload()).toMatchObject({
+      name: "orders-db",
+      description: "",
+    });
+  });
+
+  // The schema-backed path is the one every real connector takes, and it builds
+  // the payload in a different branch, so it needs its own assertion.
+  it("sends the description on the schema-backed path, without leaking it into config", async () => {
+    withSchemas(POSTGRES_SCHEMA);
+    render(<CreateConnection />);
+
+    fireEvent.change(input("connection-name"), {
+      target: { value: "orders-db" },
+    });
+    fireEvent.change(input("hostname"), {
+      target: { value: "db.example.com" },
+    });
+    fireEvent.change(screen.getByLabelText("Description"), {
+      target: { value: "Primary OLTP database" },
+    });
+
+    // With a schema present the connection must be validated before it can be
+    // created, so go through Validate first.
+    fireEvent.click(screen.getByText("Validate"));
+    await waitFor(() =>
+      expect(
+        vi
+          .mocked(createPost)
+          .mock.calls.some(([url]) => String(url).endsWith("/validate")),
+      ).toBe(true),
+    );
+    // Validation posts the same payload, so it must carry the description too.
+    const validatePayload = vi
+      .mocked(createPost)
+      .mock.calls.find(([url]) => String(url).endsWith("/validate"))?.[1] as any;
+    expect(validatePayload).toMatchObject({
+      description: "Primary OLTP database",
+    });
+
+    submit();
+    await waitFor(() => expect(lastCreatePayload()).toBeDefined());
+
+    const payload = lastCreatePayload()!;
+    expect(payload).toMatchObject({
+      type: "POSTGRES",
+      name: "orders-db",
+      description: "Primary OLTP database",
+    });
+    expect(payload.config).toEqual({ hostname: "db.example.com" });
+    expect(payload.config).not.toHaveProperty("description");
+  });
+});

--- a/debezium-platform-stage/src/pages/Connection/CreateConnection.tsx
+++ b/debezium-platform-stage/src/pages/Connection/CreateConnection.tsx
@@ -1,5 +1,5 @@
 import PageHeader from "@components/PageHeader";
-import { ActionList, ActionListGroup, ActionListItem, Alert, Button, Card, CardBody, Content, Form, FormAlert, FormFieldGroup, FormFieldGroupHeader, FormGroup, FormGroupLabelHelp, FormHelperText, HelperText, HelperTextItem, InputGroup, InputGroupItem, PageSection, Popover, TextInput } from "@patternfly/react-core";
+import { ActionList, ActionListGroup, ActionListItem, Alert, Button, Card, CardBody, Content, Form, FormAlert, FormFieldGroup, FormFieldGroupHeader, FormGroup, FormGroupLabelHelp, FormHelperText, HelperText, HelperTextItem, InputGroup, InputGroupItem, PageSection, Popover, Skeleton, TextInput } from "@patternfly/react-core";
 import * as React from "react";
 import _, { } from "lodash";
 import { Controller, useForm } from "react-hook-form";
@@ -61,7 +61,7 @@ const CreateConnection: React.FunctionComponent<ICreateConnectionProps> = ({ sel
     const [properties, setProperties] = useState<Map<string, AdditionalPropertyRow>>(() => new Map([["key0", createEmptyAdditionalPropertyRow()]]));
     const [keyCount, setKeyCount] = React.useState<number>(1);
 
-    const { data: connectionsSchema = [] } = useQuery<ConnectionsSchema[], Error>("connectionsSchema", () =>
+    const { data: connectionsSchema = [], isLoading: isSchemaLoading } = useQuery<ConnectionsSchema[], Error>("connectionsSchema", () =>
         fetchData<ConnectionsSchema[]>(`${API_URL}/api/connections/schemas`)
     );
 
@@ -303,6 +303,17 @@ const CreateConnection: React.FunctionComponent<ICreateConnectionProps> = ({ sel
 
                 <Card className="custom-card-body">
                     <CardBody isFilled>
+                        {isSchemaLoading ? (
+                            <div>
+                                <Skeleton fontSize="2xl" width="40%" />
+                                <br />
+                                <Skeleton fontSize="md" width="60%" />
+                                <br />
+                                <Skeleton fontSize="md" width="80%" />
+                                <br />
+                                <Skeleton fontSize="md" width="50%" />
+                            </div>
+                        ) : (
                         <Form id="create-connection-form" onSubmit={handleSubmit(handleSaveFromForm)} isWidthLimited>
                             {!_.isEmpty(errors) && (
                                 <FormAlert>
@@ -512,6 +523,7 @@ const CreateConnection: React.FunctionComponent<ICreateConnectionProps> = ({ sel
                                 </>
                             </FormFieldGroup>
                         </Form>
+                        )}
                     </CardBody>
                 </Card>
 

--- a/debezium-platform-stage/src/pages/Connection/CreateConnection.tsx
+++ b/debezium-platform-stage/src/pages/Connection/CreateConnection.tsx
@@ -103,6 +103,7 @@ const CreateConnection: React.FunctionComponent<ICreateConnectionProps> = ({ sel
                 return !conns.some(c => c.name === value);
             }
         ),
+        description: yup.string().notRequired(),
         ...buildNestedConnectionYupFields(selectedSchemaProperties)
     }).required() as yup.ObjectSchema<ConnectionFormValues>;
 
@@ -218,7 +219,7 @@ const CreateConnection: React.FunctionComponent<ICreateConnectionProps> = ({ sel
     };
 
     const buildConnectionPayloadOrNull = (data: ConnectionFormValues): ConnectionPayload | null => {
-        const { name } = data;
+        const { name, description } = data;
         const schemaPropertyKeys = selectedSchemaProperties?.properties
             ? Object.keys(selectedSchemaProperties.properties)
             : [];
@@ -241,11 +242,13 @@ const CreateConnection: React.FunctionComponent<ICreateConnectionProps> = ({ sel
             ? ({
                 type: selectedSchema?.type.toUpperCase() || extractConnectorType(connectionId || "").toUpperCase(),
                 config: mergedConfig,
+                description: (description as string) ?? "",
                 name: name as string,
             } as ConnectionPayload)
             : {
                 type: extractConnectorType(connectionId || "").toUpperCase(),
                 config: validation.additionalFlat,
+                description: (description as string) ?? "",
                 name: name as string,
             };
     };
@@ -338,6 +341,25 @@ const CreateConnection: React.FunctionComponent<ICreateConnectionProps> = ({ sel
                                         </HelperText>
                                     </FormHelperText>)}
 
+                            </FormGroup>
+
+                            <FormGroup
+                                label={t("connection:form.descriptionField")}
+                                fieldId={"connection-description"}
+                            >
+                                <Controller
+                                    name={"description"}
+                                    control={control}
+                                    defaultValue={""}
+                                    render={({ field }) => <TextInput id="connection-description" {...field} />}
+                                />
+                                <FormHelperText>
+                                    <HelperText>
+                                        <HelperTextItem>
+                                            {t("connection:form.descriptionFieldHelperText")}
+                                        </HelperTextItem>
+                                    </HelperText>
+                                </FormHelperText>
                             </FormGroup>
 
 

--- a/debezium-platform-stage/src/pages/Connection/EditConnection.test.tsx
+++ b/debezium-platform-stage/src/pages/Connection/EditConnection.test.tsx
@@ -1,0 +1,219 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { fireEvent, screen, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { useQuery } from "react-query";
+import { createPost, editPut, fetchDataTypeTwo } from "src/apis";
+import { EditConnection } from "./EditConnection";
+import { render } from "../../__test__/unit/test-utils";
+
+const hoisted = vi.hoisted(() => ({ search: "" }));
+
+vi.mock("react-router-dom", async (importOriginal) => {
+  const mod = await importOriginal<typeof import("react-router-dom")>();
+  return {
+    ...mod,
+    useNavigate: () => vi.fn(),
+    useParams: () => ({ connectionId: "1" }),
+    useSearchParams: () => [new URLSearchParams(hoisted.search), vi.fn()],
+  };
+});
+
+vi.mock("react-query", async (importOriginal) => {
+  const mod = await importOriginal<typeof import("react-query")>();
+  return { ...mod, useQuery: vi.fn() };
+});
+
+vi.mock("src/apis", async (importOriginal) => {
+  const mod = await importOriginal<typeof import("src/apis")>();
+  return {
+    ...mod,
+    editPut: vi.fn(),
+    createPost: vi.fn(),
+    fetchDataTypeTwo: vi.fn(),
+  };
+});
+
+vi.mock("../../appLayout/AppContext", () => ({
+  useData: () => ({
+    darkMode: false,
+    navigationCollapsed: false,
+    setDarkMode: vi.fn(),
+    updateNavigationCollapsed: vi.fn(),
+  }),
+}));
+
+const CONNECTION = {
+  id: 1,
+  name: "orders-db",
+  type: "POSTGRES",
+  description: "Primary OLTP database",
+  config: { hostname: "db.example.com" },
+};
+
+const MATCHING_SCHEMA = [
+  {
+    type: "POSTGRES",
+    schema: {
+      type: "object",
+      title: "PostgreSQL",
+      description: "PostgreSQL connection properties",
+      required: ["hostname"],
+      additionalProperties: { type: "string" },
+      properties: { hostname: { type: "string", title: "Hostname" } },
+    },
+  },
+];
+
+/** A schema list that does not contain the connection's type. */
+const UNRELATED_SCHEMA = [{ ...MATCHING_SCHEMA[0], type: "MYSQL" }];
+
+const mockApi = (schemas: unknown) => {
+  vi.mocked(fetchDataTypeTwo).mockImplementation((async (url: string) =>
+    url.endsWith("/api/connections/schemas")
+      ? { data: schemas, error: undefined }
+      : { data: CONNECTION, error: undefined }) as any);
+};
+
+const input = (id: string) => document.getElementById(id) as HTMLInputElement;
+
+const lastPutPayload = () =>
+  vi.mocked(editPut).mock.calls[0]?.[1] as Record<string, unknown> | undefined;
+
+describe("EditConnection description field", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    hoisted.search = "";
+    vi.mocked(useQuery).mockReturnValue({
+      data: [],
+      error: null,
+      isLoading: false,
+    } as any);
+    vi.mocked(editPut).mockResolvedValue({
+      data: CONNECTION,
+      error: undefined,
+    } as any);
+    vi.mocked(createPost).mockResolvedValue({
+      data: { valid: true },
+      error: undefined,
+    } as any);
+  });
+
+  it("seeds the saved description into the edit form (schema-matched connection)", async () => {
+    mockApi(MATCHING_SCHEMA);
+    render(<EditConnection />);
+    await waitFor(() =>
+      expect(input("connection-description")).toHaveValue(
+        "Primary OLTP database",
+      ),
+    );
+  });
+
+  it("seeds the saved description when no schema matches the connection type", async () => {
+    mockApi(UNRELATED_SCHEMA);
+    render(<EditConnection />);
+    await waitFor(() =>
+      expect(input("connection-description")).toHaveValue(
+        "Primary OLTP database",
+      ),
+    );
+  });
+
+  it("keeps the existing description in the payload when it is not edited", async () => {
+    mockApi(UNRELATED_SCHEMA);
+    render(<EditConnection />);
+    await waitFor(() =>
+      expect(input("connection-description")).toHaveValue(
+        "Primary OLTP database",
+      ),
+    );
+
+    fireEvent.submit(document.getElementById("create-connection-form")!);
+
+    await waitFor(() => expect(lastPutPayload()).toBeDefined());
+    expect(lastPutPayload()).toMatchObject({
+      name: "orders-db",
+      description: "Primary OLTP database",
+    });
+  });
+
+  // A successful save flips the page back to view mode, so each of these
+  // renders its own form rather than submitting twice.
+  const editDescriptionAndSubmit = async (value: string) => {
+    mockApi(UNRELATED_SCHEMA);
+    render(<EditConnection />);
+    await waitFor(() =>
+      expect(input("connection-description")).toHaveValue(
+        "Primary OLTP database",
+      ),
+    );
+    fireEvent.change(input("connection-description"), { target: { value } });
+    fireEvent.submit(document.getElementById("create-connection-form")!);
+    await waitFor(() => expect(lastPutPayload()).toBeDefined());
+  };
+
+  it("sends an edited description", async () => {
+    await editDescriptionAndSubmit("Replica used for reporting");
+    expect(lastPutPayload()).toMatchObject({
+      description: "Replica used for reporting",
+    });
+  });
+
+  it("sends an empty string once the description is cleared", async () => {
+    await editDescriptionAndSubmit("");
+    expect(lastPutPayload()).toMatchObject({ description: "" });
+  });
+
+  // The schema-backed path builds the PUT payload in a different branch, and it
+  // is the path every real connector takes, so it needs its own assertion.
+  it("sends the description on the schema-backed path, without leaking it into config", async () => {
+    mockApi(MATCHING_SCHEMA);
+    render(<EditConnection />);
+    await waitFor(() =>
+      expect(input("connection-description")).toHaveValue(
+        "Primary OLTP database",
+      ),
+    );
+
+    fireEvent.change(input("connection-description"), {
+      target: { value: "Replica used for reporting" },
+    });
+
+    // With a schema present the connection must be validated before saving.
+    fireEvent.click(screen.getByText("Validate"));
+    await waitFor(() =>
+      expect(
+        vi
+          .mocked(createPost)
+          .mock.calls.some(([url]) => String(url).endsWith("/validate")),
+      ).toBe(true),
+    );
+    const validatePayload = vi
+      .mocked(createPost)
+      .mock.calls.find(([url]) => String(url).endsWith("/validate"))?.[1] as any;
+    expect(validatePayload).toMatchObject({
+      description: "Replica used for reporting",
+    });
+
+    fireEvent.submit(document.getElementById("create-connection-form")!);
+    await waitFor(() => expect(lastPutPayload()).toBeDefined());
+
+    const payload = lastPutPayload()!;
+    expect(payload).toMatchObject({
+      type: "POSTGRES",
+      name: "orders-db",
+      description: "Replica used for reporting",
+    });
+    expect(payload.config).toEqual({ hostname: "db.example.com" });
+    expect(payload.config).not.toHaveProperty("description");
+  });
+
+  it("renders the description as read-only text in view mode", async () => {
+    hoisted.search = "state=view";
+    mockApi(UNRELATED_SCHEMA);
+    render(<EditConnection />);
+    await waitFor(() =>
+      expect(screen.getByText("Primary OLTP database")).toBeInTheDocument(),
+    );
+    expect(input("connection-description")).toBeNull();
+  });
+});

--- a/debezium-platform-stage/src/pages/Connection/EditConnection.tsx
+++ b/debezium-platform-stage/src/pages/Connection/EditConnection.tsx
@@ -116,6 +116,7 @@ const EditConnection: React.FunctionComponent<IEditConnectionProps> = () => {
                 return !conns.some(c => c.name === value);
             }
         ),
+        description: yup.string().notRequired(),
         ...buildNestedConnectionYupFields(selectedSchema?.schema)
     }).required() as yup.ObjectSchema<ConnectionFormValues>;
 
@@ -123,6 +124,7 @@ const EditConnection: React.FunctionComponent<IEditConnectionProps> = () => {
         {
             defaultValues: {
                 name: connection?.name || "",
+                description: connection?.description || "",
                 ...(connection?.config
                     ? flatConnectionConfigToRhfShape(connection.config as Record<string, unknown>)
                     : {}),
@@ -160,6 +162,7 @@ const EditConnection: React.FunctionComponent<IEditConnectionProps> = () => {
                     });
                     reset({
                         name: response.data?.name || "",
+                        description: response.data?.description || "",
                         ...flatConnectionConfigToRhfShape(formFields),
                     });
                     // Assign the remaining properties to setConfigProperties
@@ -173,6 +176,7 @@ const EditConnection: React.FunctionComponent<IEditConnectionProps> = () => {
 
                     reset({
                         name: response.data?.name || "",
+                        description: response.data?.description || "",
                     });
                     setConfigPropertiesFromApi(response.data?.config as ConnectionAdditionalConfig ?? {});
                 }
@@ -323,7 +327,7 @@ const EditConnection: React.FunctionComponent<IEditConnectionProps> = () => {
     };
 
     const buildConnectionPayloadOrNull = (data: ConnectionFormValues): ConnectionPayload | null => {
-        const { name } = data;
+        const { name, description } = data;
         const schemaPropertyKeys = selectedSchema?.schema?.properties
             ? Object.keys(selectedSchema.schema.properties)
             : [];
@@ -346,11 +350,13 @@ const EditConnection: React.FunctionComponent<IEditConnectionProps> = () => {
             ? ({
                   type: selectedSchema?.type.toUpperCase() || connection?.type.toUpperCase() || "",
                   config: mergedConfig,
+                  description: (description as string) ?? "",
                   name: name as string,
               } as ConnectionPayload)
             : {
                   type: connection?.type.toUpperCase() || "",
                   config: validation.additionalFlat,
+                  description: (description as string) ?? "",
                   name: name as string,
               };
     };
@@ -456,6 +462,26 @@ const EditConnection: React.FunctionComponent<IEditConnectionProps> = () => {
                                         </HelperText>
                                     </FormHelperText>)}
 
+                            </FormGroup>
+
+                            <FormGroup
+                                label={t("connection:form.descriptionField")}
+                                fieldId={"connection-description"}
+                            >
+                                <Controller
+                                    name={"description"}
+                                    control={control}
+                                    defaultValue={""}
+                                    render={({ field }) => viewMode ? <ReviewValueSpan raw={field.value} /> : <TextInput id="connection-description" {...field} />}
+                                />
+                                {!viewMode && (
+                                    <FormHelperText>
+                                        <HelperText>
+                                            <HelperTextItem>
+                                                {t("connection:form.descriptionFieldHelperText")}
+                                            </HelperTextItem>
+                                        </HelperText>
+                                    </FormHelperText>)}
                             </FormGroup>
 
 


### PR DESCRIPTION
Fixes debezium/dbz#2250

## Description

Adds the connection `description` field to the UI. This is the frontend half of debezium/dbz#1245, whose backend and API work merged in #309.

#309 already shipped the type side — `description?: string` on both `ConnectionPayload` and `Connection` in `src/apis/apis.tsx`, plus sample values in `src/__mocks__/data/Connections.json`. This puts the UI on top of it.

**`CreateConnection.tsx`**
- an optional description `TextInput` directly below the name field, with helper text
- declared as `description: yup.string().notRequired()` in the form schema
- carried into the object built by `buildConnectionPayloadOrNull`, in both the schema and the no-schema branch

**`EditConnection.tsx`**
- the saved description is seeded from the fetched connection in the `useForm` defaults and in **both** `reset()` branches. Without that, opening an existing connection and saving any unrelated change silently wipes its description.
- rendered read-only in view mode through the existing `ReviewValueSpan`, so a connection with no description shows the same `—` placeholder as the other fields
- same payload wiring on the PUT

**Locales** — `connection:form.descriptionField` and `connection:form.descriptionFieldHelperText`, added to both `en` and `it`.

### The second commit: resetting scroll on navigation

The first push of this branch turned two long-standing Cypress assertions red — `should display create connection form for PostgreSQL` and `… for Kafka destination`, both at `cy.contains('h1', 'Create connection').should('be.visible')`. I reproduced it locally against the compose stack and measured it rather than guessing, and it is worth explaining because the cause is not the field itself.

`<main id="primary-app-container">` is the app's scroll container, and a client-side route change leaves its `scrollTop` untouched. In those two tests Cypress scrolls the catalog to reach the connector card, clicks it, and React Router swaps in the create page with that offset still applied. The offset only survives if the new page is tall enough to keep it — otherwise the browser clamps it away.

Measured on the create-connection page immediately after that navigation:

| | `scrollTop` | max scroll | `<h1>` top |
| --- | --- | --- | --- |
| before this branch | 48.5 | 624 | **78** (container starts at 73 — visible by ~5px) |
| with the description field | 160.5 | 736 | **−34** (clipped) |
| with the scroll reset | 0 | 736 | **126** (same as a direct visit) |

So the assertions were passing with about five pixels to spare, and one extra form row was enough to tip them over. The test is right — landing on a page with its heading above the fold is a real defect — so the second commit resets `scrollTop` on `location.pathname` change, next to the existing pathname-keyed effect in `AppLayout`. It is five lines and needs no new imports.

I have kept it as a separate commit since it is a distinct concern; happy to split it into its own PR if you would rather review it on its own, though this branch does need it to stay green.

### A few choices worth calling out

- **Which namespace the labels live in.** `CreateSchemaForm` keeps its description strings in `common` because it is shared between source and destination. `pipeline` and `transform` keep theirs in their own namespace. A connection-only form falls in the second group, so the keys are in `connection.json`.
- **Blank description.** The payload always carries `description`, sending `""` when the field is empty, which is what `CreateSchemaForm.tsx` does. That makes clearing a description behave the same way regardless of how the mapper treats an absent field, and `reviewValue()` already renders `""` as `—`.
- **`/api/connections/validate`** binds the same `ConnectionRequest` record as create and update, so the extra field rides along harmlessly on validation requests.
- **No description column in the connections list.** Sources and destinations have had a description for a while and `SourceSinkTable` still does not show it, so I left `ConnectionTable` alone for consistency. Happy to add it if you would rather have it.
- **`ServerConfigModal` left alone.** It is the other place that POSTs to `/api/connections`, but it auto-provisions connections with faker-generated names while importing a Debezium Server config, so there is no user-entered description to carry. Easy to add a canned one there later if that would be useful.

## Testing

New `CreateConnection.test.tsx` (4 tests) and `EditConnection.test.tsx` (7 tests). All eleven fail when the two source files are reverted to `main`, so they are genuine regression guards rather than tests that pass by construction — the edit-page ones specifically cover the wipe-on-save case described above.

Both components build the payload in two branches, depending on whether a schema was resolved for the connection type. Since every connector in `connection-schemas.json` takes the schema-backed branch, each component has a test that drives it end to end — Validate, then save — and asserts both that `description` reaches the payload and that it does **not** appear in `config`. Removing only the schema-branch `description` line fails exactly those two tests and nothing else.

Local run of the `stage-workflow` chain:

| step | result |
| --- | --- |
| `yarn lint` | 0 errors (the 35 warnings are pre-existing; none in `src/pages/Connection`) |
| `yarn type-check` | clean |
| `yarn build` | ok |
| `yarn test` | 70 files / 402 tests pass, up from 68 / 391 |
| `yarn cypress run` | all 6 specs, 134 / 134 pass against the compose stack |

The Cypress run is the full suite, not just `connection.cy.ts`, because the scroll change touches every page.

## Two pre-existing things I noticed but did not touch

- `connection:form.nameExists` is referenced in both files but is missing from both locale files, so it only ever renders its inline English default. The new `form` block would be its natural home — say the word and I will add it here or in a separate PR.
- In `EditConnection`'s fetch effect, neither `reset()` branch runs when a connector's type matches a schema but the API returns a falsy `config`. On that path `name` is left blank too, and `name` is `required()`, so the form simply refuses to submit rather than saving anything away — the visible symptom is view mode showing `—`. Pre-existing and not specific to this change.
- The single-input form field name is `description`, matching `name` alongside it. As with `name`, a connector schema that declared a config property of the same literal name would shadow it, since `buildNestedConnectionYupFields` is spread after the explicit entries. None of the sixteen schemas in `connection-schemas.json` declares either, so this is theoretical today — mentioning it only because I checked.

## PR Checklist

- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
