### PR TITLE
debezium/dbz#2308 Stop reporting an empty predicate on the transforms API

### DIFF
--- a/debezium-platform-conductor/src/main/java/io/debezium/platform/api/dto/TransformResponse.java
+++ b/debezium-platform-conductor/src/main/java/io/debezium/platform/api/dto/TransformResponse.java
@@ -8,6 +8,8 @@ package io.debezium.platform.api.dto;
 import java.util.Map;
 import java.util.Set;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
 public record TransformResponse(
         Long id,
         String name,
@@ -16,5 +18,5 @@ public record TransformResponse(
         String schema,
         Set<NamedRef> vaults,
         Map<String, Object> config,
-        PredicateDto predicate) {
+        @JsonInclude(JsonInclude.Include.NON_NULL) PredicateDto predicate) {
 }

--- a/debezium-platform-conductor/src/main/java/io/debezium/platform/api/mapper/TransformMapper.java
+++ b/debezium-platform-conductor/src/main/java/io/debezium/platform/api/mapper/TransformMapper.java
@@ -28,7 +28,18 @@ public abstract class TransformMapper extends BaseMapper {
 
     public abstract NamedRef vaultToRef(VaultReference ref);
 
-    public abstract PredicateDto predicateToDto(Predicate predicate);
+    /**
+     * The predicate is an {@code @Embeddable} on {@code TransformEntity}, so it always materialises
+     * even when no predicate was configured, leaving every field unset. Treat that as "no predicate"
+     * rather than reporting it as one, matching how the operator mapper decides whether a transform
+     * has a predicate.
+     */
+    public PredicateDto predicateToDto(Predicate predicate) {
+        if (predicate == null || predicate.getType() == null) {
+            return null;
+        }
+        return new PredicateDto(predicate.getType(), predicate.getConfig(), predicate.isNegate());
+    }
 
     @Mapping(target = "id", ignore = true)
     @Mapping(target = "vaults", ignore = true)

--- a/debezium-platform-conductor/src/test/java/io/debezium/platform/api/TransformResourceIT.java
+++ b/debezium-platform-conductor/src/test/java/io/debezium/platform/api/TransformResourceIT.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.platform.api;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.http.ContentType;
+
+@QuarkusTest
+class TransformResourceIT {
+
+    @Test
+    @DisplayName("A transform created without a predicate does not report one")
+    void transformWithoutPredicateOmitsPredicate() {
+        String body = """
+                {
+                    "name": "transform-without-predicate-%s",
+                    "description": "no predicate configured",
+                    "type": "io.debezium.transforms.ExtractNewRecordState",
+                    "schema": "string",
+                    "vaults": [],
+                    "config": {
+                        "add.fields": "op"
+                    }
+                }
+                """.formatted(System.nanoTime());
+
+        Integer id = given()
+                .contentType(ContentType.JSON)
+                .body(body)
+                .when().post("/api/transforms")
+                .then()
+                .statusCode(201)
+                .body("$", not(hasKey("predicate")))
+                .extract().path("id");
+
+        given()
+                .when().get("/api/transforms/{id}", id)
+                .then()
+                .statusCode(200)
+                .body("$", not(hasKey("predicate")));
+    }
+
+    @Test
+    @DisplayName("A transform created with a predicate round-trips it unchanged")
+    void transformWithPredicateKeepsPredicate() {
+        String body = """
+                {
+                    "name": "transform-with-predicate-%s",
+                    "description": "predicate configured",
+                    "type": "io.debezium.transforms.ExtractNewRecordState",
+                    "schema": "string",
+                    "vaults": [],
+                    "config": {
+                        "add.fields": "op"
+                    },
+                    "predicate": {
+                        "type": "org.apache.kafka.connect.transforms.predicates.TopicNameMatches",
+                        "config": {
+                            "pattern": "orders.*"
+                        },
+                        "negate": true
+                    }
+                }
+                """.formatted(System.nanoTime());
+
+        Integer id = given()
+                .contentType(ContentType.JSON)
+                .body(body)
+                .when().post("/api/transforms")
+                .then()
+                .statusCode(201)
+                .extract().path("id");
+
+        given()
+                .when().get("/api/transforms/{id}", id)
+                .then()
+                .statusCode(200)
+                .body("predicate.type", is("org.apache.kafka.connect.transforms.predicates.TopicNameMatches"))
+                .body("predicate.config.pattern", equalTo("orders.*"))
+                .body("predicate.negate", is(true));
+    }
+}


### PR DESCRIPTION
Fixes debezium/dbz#2308

## Description

`GET` and `POST /transforms` report a predicate for transforms that have none:

```json
{"id":14,"name":"...","predicate":{"type":null,"config":null,"negate":false}}
```

`TransformEntity.Predicate` is an `@Embeddable`, so Hibernate materialises it whether or not a predicate was configured, leaving every field unset. The generated mapper only null-checks the reference, never its contents, so that empty instance is serialised as though it were a real predicate.

The write path already guards this — `TransformMapper.applyToView` only touches the predicate when the request carries one — and the operator side already has the right emptiness test, at `environment/operator/PipelineMapper.java:318`:

```java
return transform.getPredicate() != null && transform.getPredicate().getType() != null;
```

This applies the same test on the read path: `predicateToDto` returns `null` for a predicate with no type, and the response field is annotated `@JsonInclude(NON_NULL)` so the key is omitted rather than serialised as `"predicate": null`.

### On the wire shape

The issue asks for `predicate: {}` or no `predicate` object at all; I went with omitting the key. Worth flagging two things so you can redirect cheaply if you would rather have `{}`:

- The mapper change alone is not enough — it leaves the key present with a `null` value, because this project has no global Jackson inclusion setting and no other `@JsonInclude` usage today. The annotation is what actually removes the key.
- It is deliberately on the record component and not on the type. Type-level `NON_NULL` would silently drop `description`, `schema` and every other unset field from every transform response, which is a much bigger change than this issue is asking for.

Existing consumers are unaffected either way: `apis.tsx` already declares `predicate?`, and every frontend read of it is a truthiness check.

## Testing

New `TransformResourceIT` — `SourceResourceIT`-style `@QuarkusTest` + RestAssured, no operator or k8s harness needed:

- a transform created without a predicate has no `predicate` key, on both the create response and a subsequent `GET`
- a transform created with a predicate round-trips type, config and negate unchanged

Both pass with the change (2/2). With `TransformMapper` and `TransformResponse` reverted to `main`, the first test fails on the missing-key assertion and the round-trip test still passes, so the new coverage is pinned to this behaviour rather than passing by construction.

`process-sources checkstyle:checkstyle` with the formatter and import-order validation that CI runs is clean.

One note on my local run: the failsafe pass also tries to start `ghcr.io/project-zot/zot-linux-amd64`, which has no arm64 image, so on Apple Silicon that dev service fails before the test body executes. The results above come from the surefire pass, which brings up the same Postgres dev service and runs the same class. This does not affect CI on `ubuntu-latest`.

## PR Checklist

- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
