### PR TITLE
debezium/dbz#2367 Generate OpenAPI spec during build

### DIFF
--- a/debezium-platform-conductor/src/main/resources/application.yml
+++ b/debezium-platform-conductor/src/main/resources/application.yml
@@ -100,6 +100,8 @@ destinations:
     connection:
       timeout: 60
 quarkus:
+  smallrye-openapi:
+    store-schema-directory: ../openapi
   hibernate-orm:
     mapping:
       format:

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -1,0 +1,1906 @@
+{
+  "openapi" : "3.1.0",
+  "paths" : {
+    "/api/catalog" : {
+      "get" : {
+        "summary" : "Returns all available components for the current application version",
+        "parameters" : [ {
+          "name" : "type",
+          "in" : "query",
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "object"
+                }
+              }
+            }
+          }
+        },
+        "tags" : [ "Catalog Resource" ]
+      }
+    },
+    "/api/catalog/{type}/{class}" : {
+      "get" : {
+        "summary" : "Returns descriptors for a specific component using current application version",
+        "parameters" : [ {
+          "name" : "class",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "type",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "object"
+                }
+              }
+            }
+          }
+        },
+        "tags" : [ "Catalog Resource" ]
+      }
+    },
+    "/api/catalog/{version}" : {
+      "get" : {
+        "summary" : "Returns all available components for a specific version",
+        "parameters" : [ {
+          "name" : "version",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "type",
+          "in" : "query",
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "object"
+                }
+              }
+            }
+          }
+        },
+        "tags" : [ "Catalog Resource" ]
+      }
+    },
+    "/api/catalog/{version}/{type}/{class}" : {
+      "get" : {
+        "summary" : "Returns descriptors for a specific component",
+        "parameters" : [ {
+          "name" : "class",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "type",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "version",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "object"
+                }
+              }
+            }
+          }
+        },
+        "tags" : [ "Catalog Resource" ]
+      }
+    },
+    "/api/connections" : {
+      "post" : {
+        "summary" : "Creates new connection",
+        "tags" : [ "connections" ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/ConnectionRequest"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "201" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "string",
+                  "format" : "uri"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Bad Request"
+          }
+        }
+      },
+      "get" : {
+        "summary" : "Returns all available connections",
+        "tags" : [ "connections" ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/ConnectionResponse"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/connections/schemas" : {
+      "get" : {
+        "summary" : "Returns a list of JSON schema describing the required field for a Connection",
+        "tags" : [ "connections" ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/connections/validate" : {
+      "post" : {
+        "summary" : "Verify that the connection is valid",
+        "tags" : [ "connections" ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/ConnectionRequest"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "object",
+                  "properties" : {
+                    "valid" : {
+                      "type" : "boolean"
+                    },
+                    "message" : {
+                      "type" : "string"
+                    },
+                    "errorType" : {
+                      "type" : "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Bad Request"
+          }
+        }
+      }
+    },
+    "/api/connections/{id}" : {
+      "put" : {
+        "summary" : "Updates an existing connection",
+        "tags" : [ "connections" ],
+        "parameters" : [ {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "integer",
+            "format" : "int64"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/ConnectionRequest"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ConnectionResponse"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Bad Request"
+          }
+        }
+      },
+      "get" : {
+        "summary" : "Returns a connection with given id",
+        "tags" : [ "connections" ],
+        "parameters" : [ {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "integer",
+            "format" : "int64"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ConnectionResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete" : {
+        "summary" : "Deletes an existing connection",
+        "tags" : [ "connections" ],
+        "parameters" : [ {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "integer",
+            "format" : "int64"
+          }
+        } ],
+        "responses" : {
+          "204" : { }
+        }
+      }
+    },
+    "/api/connections/{id}/collections" : {
+      "get" : {
+        "summary" : "Returns a list of collection names available on the source",
+        "tags" : [ "connections" ],
+        "parameters" : [ {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "integer",
+            "format" : "int64"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "object",
+                  "properties" : {
+                    "catalogs" : {
+                      "type" : "array",
+                      "items" : {
+                        "$ref" : "#/components/schemas/CatalogNode"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/destinations" : {
+      "post" : {
+        "summary" : "Creates new destination",
+        "tags" : [ "destinations" ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/DestinationRequest"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "201" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "string",
+                  "format" : "uri"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Bad Request"
+          }
+        }
+      },
+      "get" : {
+        "summary" : "Returns all available destinations",
+        "tags" : [ "destinations" ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/DestinationResponse"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/destinations/{id}" : {
+      "put" : {
+        "summary" : "Updates an existing destination",
+        "tags" : [ "destinations" ],
+        "parameters" : [ {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "integer",
+            "format" : "int64"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/DestinationRequest"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/DestinationResponse"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Bad Request"
+          }
+        }
+      },
+      "get" : {
+        "summary" : "Returns a destination with given id",
+        "tags" : [ "destinations" ],
+        "parameters" : [ {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "integer",
+            "format" : "int64"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/DestinationResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete" : {
+        "summary" : "Deletes an existing destination",
+        "tags" : [ "destinations" ],
+        "parameters" : [ {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "integer",
+            "format" : "int64"
+          }
+        } ],
+        "responses" : {
+          "204" : { }
+        }
+      }
+    },
+    "/api/monitoring/panels" : {
+      "get" : {
+        "summary" : "List available monitoring panels",
+        "tags" : [ "Monitoring" ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/PanelsListResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/monitoring/panels/{id}/query" : {
+      "get" : {
+        "summary" : "Query monitoring panel data for a specific pipeline",
+        "tags" : [ "Monitoring" ],
+        "parameters" : [ {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "description" : "End time (ISO 8601)",
+          "required" : true,
+          "name" : "end",
+          "in" : "query",
+          "schema" : {
+            "$ref" : "#/components/schemas/Instant"
+          }
+        }, {
+          "description" : "Pipeline identifier",
+          "required" : true,
+          "name" : "pipeline_id",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "pattern" : "[a-zA-Z0-9_-]+"
+          }
+        }, {
+          "description" : "Start time (ISO 8601)",
+          "required" : true,
+          "name" : "start",
+          "in" : "query",
+          "schema" : {
+            "$ref" : "#/components/schemas/Instant"
+          }
+        }, {
+          "description" : "Query resolution step (e.g. 15s, 1m)",
+          "name" : "step",
+          "in" : "query",
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/PanelQueryResponse"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Invalid parameters",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "object"
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "Panel not found",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "object"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/pipelines" : {
+      "post" : {
+        "summary" : "Creates new pipeline",
+        "tags" : [ "pipelines" ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/PipelineRequest"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "201" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "string",
+                  "format" : "uri"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Bad Request"
+          }
+        }
+      },
+      "get" : {
+        "summary" : "Returns all available pipelines",
+        "tags" : [ "pipelines" ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/PipelineResponse"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/pipelines/{id}" : {
+      "put" : {
+        "summary" : "Updates an existing pipeline",
+        "tags" : [ "pipelines" ],
+        "parameters" : [ {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "integer",
+            "format" : "int64"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/PipelineUpdateRequest"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/PipelineResponse"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Bad Request"
+          }
+        }
+      },
+      "get" : {
+        "summary" : "Returns a pipeline with given id",
+        "tags" : [ "pipelines" ],
+        "parameters" : [ {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "integer",
+            "format" : "int64"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/PipelineResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete" : {
+        "summary" : "Deletes an existing pipeline",
+        "tags" : [ "pipelines" ],
+        "parameters" : [ {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "integer",
+            "format" : "int64"
+          }
+        } ],
+        "responses" : {
+          "204" : { }
+        }
+      }
+    },
+    "/api/pipelines/{id}/logs" : {
+      "get" : {
+        "summary" : "Returns logs for pipeline with given id",
+        "tags" : [ "pipelines" ],
+        "parameters" : [ {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "integer",
+            "format" : "int64"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "text/plain" : {
+                "schema" : {
+                  "type" : "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/pipelines/{id}/signals" : {
+      "post" : {
+        "summary" : "Send signal to pipeline with given id",
+        "tags" : [ "pipelines" ],
+        "parameters" : [ {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "integer",
+            "format" : "int64"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/SignalRequest"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "202" : {
+            "description" : "Signal correctly sent to the pipeline",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/SignalResponse"
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "Pipeline not found"
+          },
+          "400" : {
+            "description" : "Bad Request"
+          }
+        }
+      }
+    },
+    "/api/sources" : {
+      "post" : {
+        "summary" : "Creates new source",
+        "tags" : [ "sources" ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/SourceRequest"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "201" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "string",
+                  "format" : "uri"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Bad Request"
+          }
+        }
+      },
+      "get" : {
+        "summary" : "Returns all available sources",
+        "tags" : [ "sources" ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/SourceResponse"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/sources/signals/verify" : {
+      "post" : {
+        "summary" : "Verify that signal data collection is configured correctly",
+        "tags" : [ "sources" ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/SignalCollectionVerifyRequest"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "object",
+                  "properties" : {
+                    "exists" : {
+                      "type" : "boolean"
+                    },
+                    "message" : {
+                      "type" : "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Bad Request"
+          }
+        }
+      }
+    },
+    "/api/sources/{id}" : {
+      "put" : {
+        "summary" : "Updates an existing source",
+        "tags" : [ "sources" ],
+        "parameters" : [ {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "integer",
+            "format" : "int64"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/SourceRequest"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/SourceResponse"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Bad Request"
+          }
+        }
+      },
+      "get" : {
+        "summary" : "Returns a source with given id",
+        "tags" : [ "sources" ],
+        "parameters" : [ {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "integer",
+            "format" : "int64"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/SourceResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete" : {
+        "summary" : "Deletes an existing source",
+        "tags" : [ "sources" ],
+        "parameters" : [ {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "integer",
+            "format" : "int64"
+          }
+        } ],
+        "responses" : {
+          "204" : { }
+        }
+      }
+    },
+    "/api/transforms" : {
+      "post" : {
+        "summary" : "Creates new transform",
+        "tags" : [ "transforms" ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/TransformRequest"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "201" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "string",
+                  "format" : "uri"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Bad Request"
+          }
+        }
+      },
+      "get" : {
+        "summary" : "Returns all available transformations",
+        "tags" : [ "transforms" ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/TransformResponse"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/transforms/{id}" : {
+      "put" : {
+        "summary" : "Updates an existing transform",
+        "tags" : [ "transforms" ],
+        "parameters" : [ {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "integer",
+            "format" : "int64"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/TransformRequest"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/TransformResponse"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Bad Request"
+          }
+        }
+      },
+      "get" : {
+        "summary" : "Returns a transform with given id",
+        "tags" : [ "transforms" ],
+        "parameters" : [ {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "integer",
+            "format" : "int64"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/TransformResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete" : {
+        "summary" : "Deletes an existing transform",
+        "tags" : [ "transforms" ],
+        "parameters" : [ {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "integer",
+            "format" : "int64"
+          }
+        } ],
+        "responses" : {
+          "204" : { }
+        }
+      }
+    },
+    "/api/vaults" : {
+      "post" : {
+        "summary" : "Creates new vault",
+        "tags" : [ "vaults" ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/VaultRequest"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "201" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "string",
+                  "format" : "uri"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Bad Request"
+          }
+        }
+      },
+      "get" : {
+        "summary" : "Returns all available vaults",
+        "tags" : [ "vaults" ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/VaultResponse"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/vaults/{id}" : {
+      "put" : {
+        "summary" : "Updates an existing vault",
+        "tags" : [ "vaults" ],
+        "parameters" : [ {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "integer",
+            "format" : "int64"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/VaultRequest"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/VaultResponse"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Bad Request"
+          }
+        }
+      },
+      "get" : {
+        "summary" : "Returns a vault with given id",
+        "tags" : [ "vaults" ],
+        "parameters" : [ {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "integer",
+            "format" : "int64"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/VaultResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete" : {
+        "summary" : "Deletes an existing vault",
+        "tags" : [ "vaults" ],
+        "parameters" : [ {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "integer",
+            "format" : "int64"
+          }
+        } ],
+        "responses" : {
+          "204" : { }
+        }
+      }
+    }
+  },
+  "tags" : [ {
+    "name" : "Monitoring",
+    "description" : "Pipeline monitoring and metrics"
+  }, {
+    "name" : "connections"
+  }, {
+    "name" : "destinations"
+  }, {
+    "name" : "pipelines"
+  }, {
+    "name" : "sources"
+  }, {
+    "name" : "transforms"
+  }, {
+    "name" : "vaults"
+  } ],
+  "components" : {
+    "schemas" : {
+      "CatalogNode" : {
+        "type" : "object",
+        "properties" : {
+          "name" : {
+            "type" : "string"
+          },
+          "schemas" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/SchemaNode"
+            }
+          },
+          "totalCollections" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        }
+      },
+      "CollectionNode" : {
+        "type" : "object",
+        "properties" : {
+          "name" : {
+            "type" : "string"
+          },
+          "fullyQualifiedName" : {
+            "type" : "string"
+          }
+        }
+      },
+      "ConnectionRequest" : {
+        "type" : "object",
+        "required" : [ "name", "type" ],
+        "properties" : {
+          "name" : {
+            "type" : "string",
+            "minLength" : 1
+          },
+          "description" : {
+            "type" : "string"
+          },
+          "type" : {
+            "$ref" : "#/components/schemas/Type"
+          },
+          "config" : {
+            "type" : "object",
+            "additionalProperties" : { }
+          }
+        }
+      },
+      "ConnectionResponse" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "integer",
+            "format" : "int64"
+          },
+          "name" : {
+            "type" : "string"
+          },
+          "description" : {
+            "type" : "string"
+          },
+          "type" : {
+            "$ref" : "#/components/schemas/Type"
+          },
+          "config" : {
+            "type" : "object",
+            "additionalProperties" : { }
+          }
+        }
+      },
+      "DestinationRequest" : {
+        "type" : "object",
+        "required" : [ "name", "type", "schema" ],
+        "properties" : {
+          "name" : {
+            "type" : "string",
+            "minLength" : 1
+          },
+          "description" : {
+            "type" : "string"
+          },
+          "type" : {
+            "type" : "string",
+            "minLength" : 1
+          },
+          "schema" : {
+            "type" : "string",
+            "minLength" : 1
+          },
+          "connection" : {
+            "$ref" : "#/components/schemas/NamedRef"
+          },
+          "vaults" : {
+            "type" : "array",
+            "uniqueItems" : true,
+            "items" : {
+              "$ref" : "#/components/schemas/NamedRef"
+            }
+          },
+          "config" : {
+            "type" : "object",
+            "additionalProperties" : { }
+          }
+        }
+      },
+      "DestinationResponse" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "integer",
+            "format" : "int64"
+          },
+          "name" : {
+            "type" : "string"
+          },
+          "description" : {
+            "type" : "string"
+          },
+          "type" : {
+            "type" : "string"
+          },
+          "schema" : {
+            "type" : "string"
+          },
+          "connection" : {
+            "$ref" : "#/components/schemas/NamedRef"
+          },
+          "vaults" : {
+            "type" : "array",
+            "uniqueItems" : true,
+            "items" : {
+              "$ref" : "#/components/schemas/NamedRef"
+            }
+          },
+          "config" : {
+            "type" : "object",
+            "additionalProperties" : { }
+          }
+        }
+      },
+      "Instant" : {
+        "type" : "string",
+        "format" : "date-time",
+        "examples" : [ "2022-03-10T16:15:50Z" ]
+      },
+      "Metadata" : {
+        "type" : "object",
+        "properties" : {
+          "queryDurationMs" : {
+            "type" : "integer",
+            "format" : "int64"
+          }
+        }
+      },
+      "NamedRef" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "integer",
+            "format" : "int64"
+          },
+          "name" : {
+            "type" : "string"
+          }
+        }
+      },
+      "PanelQueryResponse" : {
+        "type" : "object",
+        "properties" : {
+          "panelId" : {
+            "type" : "string"
+          },
+          "pipelineId" : {
+            "type" : "string"
+          },
+          "timeRange" : {
+            "$ref" : "#/components/schemas/TimeRange"
+          },
+          "series" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/TimeSeries"
+            }
+          },
+          "metadata" : {
+            "$ref" : "#/components/schemas/Metadata"
+          }
+        }
+      },
+      "PanelResponse" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string"
+          },
+          "title" : {
+            "type" : "string"
+          },
+          "description" : {
+            "type" : "string"
+          },
+          "category" : {
+            "type" : "string"
+          },
+          "unit" : {
+            "type" : "string"
+          },
+          "visualization" : {
+            "$ref" : "#/components/schemas/Visualization"
+          }
+        }
+      },
+      "PanelsListResponse" : {
+        "type" : "object",
+        "properties" : {
+          "panels" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/PanelResponse"
+            }
+          }
+        }
+      },
+      "PipelineRequest" : {
+        "type" : "object",
+        "required" : [ "name", "source", "destination", "logLevel" ],
+        "properties" : {
+          "name" : {
+            "type" : "string",
+            "minLength" : 1
+          },
+          "description" : {
+            "type" : "string"
+          },
+          "source" : {
+            "$ref" : "#/components/schemas/NamedRef"
+          },
+          "destination" : {
+            "$ref" : "#/components/schemas/NamedRef"
+          },
+          "transforms" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/NamedRef"
+            }
+          },
+          "logLevel" : {
+            "type" : "string",
+            "minLength" : 1
+          },
+          "logLevels" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "type" : "string"
+            }
+          }
+        }
+      },
+      "PipelineResponse" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "integer",
+            "format" : "int64"
+          },
+          "name" : {
+            "type" : "string"
+          },
+          "description" : {
+            "type" : "string"
+          },
+          "source" : {
+            "$ref" : "#/components/schemas/NamedRef"
+          },
+          "destination" : {
+            "$ref" : "#/components/schemas/NamedRef"
+          },
+          "transforms" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/NamedRef"
+            }
+          },
+          "logLevel" : {
+            "type" : "string"
+          },
+          "logLevels" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "type" : "string"
+            }
+          },
+          "status" : {
+            "$ref" : "#/components/schemas/PipelineStatus"
+          },
+          "errorMessage" : {
+            "type" : "string"
+          }
+        }
+      },
+      "PipelineStatus" : {
+        "type" : "string",
+        "enum" : [ "DEPLOYING", "RUNNING", "STOPPED", "FAILED" ]
+      },
+      "PipelineUpdateRequest" : {
+        "type" : "object",
+        "required" : [ "name", "logLevel" ],
+        "properties" : {
+          "name" : {
+            "type" : "string",
+            "minLength" : 1
+          },
+          "description" : {
+            "type" : "string"
+          },
+          "transforms" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/NamedRef"
+            }
+          },
+          "logLevel" : {
+            "type" : "string",
+            "minLength" : 1
+          },
+          "logLevels" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "type" : "string"
+            }
+          }
+        }
+      },
+      "PredicateDto" : {
+        "type" : "object",
+        "properties" : {
+          "type" : {
+            "type" : "string"
+          },
+          "config" : {
+            "type" : "object",
+            "additionalProperties" : { }
+          },
+          "negate" : {
+            "type" : "boolean"
+          }
+        }
+      },
+      "SchemaNode" : {
+        "type" : "object",
+        "properties" : {
+          "name" : {
+            "type" : "string"
+          },
+          "collections" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/CollectionNode"
+            }
+          },
+          "collectionCount" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        }
+      },
+      "Signal" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string"
+          }
+        }
+      },
+      "SignalCollectionVerifyRequest" : {
+        "type" : "object",
+        "properties" : {
+          "connectionId" : {
+            "type" : "integer",
+            "format" : "int64"
+          },
+          "fullyQualifiedTableName" : {
+            "type" : "string"
+          }
+        }
+      },
+      "SignalRequest" : {
+        "type" : "object",
+        "required" : [ "id", "type", "data" ],
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "minLength" : 1
+          },
+          "type" : {
+            "type" : "string",
+            "minLength" : 1
+          },
+          "data" : {
+            "type" : "string",
+            "minLength" : 1
+          },
+          "additionalData" : {
+            "type" : "object",
+            "additionalProperties" : { }
+          }
+        }
+      },
+      "SignalResponse" : {
+        "type" : "object",
+        "properties" : {
+          "signal" : {
+            "$ref" : "#/components/schemas/Signal"
+          }
+        }
+      },
+      "SourceRequest" : {
+        "type" : "object",
+        "required" : [ "name", "type", "schema" ],
+        "properties" : {
+          "name" : {
+            "type" : "string",
+            "minLength" : 1
+          },
+          "description" : {
+            "type" : "string"
+          },
+          "type" : {
+            "type" : "string",
+            "minLength" : 1
+          },
+          "schema" : {
+            "type" : "string",
+            "minLength" : 1
+          },
+          "connection" : {
+            "$ref" : "#/components/schemas/NamedRef"
+          },
+          "vaults" : {
+            "type" : "array",
+            "uniqueItems" : true,
+            "items" : {
+              "$ref" : "#/components/schemas/NamedRef"
+            }
+          },
+          "config" : {
+            "type" : "object",
+            "additionalProperties" : { }
+          }
+        }
+      },
+      "SourceResponse" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "integer",
+            "format" : "int64"
+          },
+          "name" : {
+            "type" : "string"
+          },
+          "description" : {
+            "type" : "string"
+          },
+          "type" : {
+            "type" : "string"
+          },
+          "schema" : {
+            "type" : "string"
+          },
+          "connection" : {
+            "$ref" : "#/components/schemas/NamedRef"
+          },
+          "vaults" : {
+            "type" : "array",
+            "uniqueItems" : true,
+            "items" : {
+              "$ref" : "#/components/schemas/NamedRef"
+            }
+          },
+          "config" : {
+            "type" : "object",
+            "additionalProperties" : { }
+          }
+        }
+      },
+      "TimeRange" : {
+        "type" : "object",
+        "properties" : {
+          "start" : {
+            "type" : "string"
+          },
+          "end" : {
+            "type" : "string"
+          },
+          "step" : {
+            "type" : "string"
+          }
+        }
+      },
+      "TimeSeries" : {
+        "type" : "object",
+        "properties" : {
+          "labels" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "type" : "string"
+            }
+          },
+          "datapoints" : {
+            "type" : "array",
+            "items" : {
+              "type" : "array",
+              "items" : {
+                "type" : "number",
+                "format" : "double"
+              }
+            }
+          }
+        }
+      },
+      "TransformRequest" : {
+        "type" : "object",
+        "required" : [ "name", "type", "schema" ],
+        "properties" : {
+          "name" : {
+            "type" : "string",
+            "minLength" : 1
+          },
+          "description" : {
+            "type" : "string"
+          },
+          "type" : {
+            "type" : "string",
+            "minLength" : 1
+          },
+          "schema" : {
+            "type" : "string",
+            "minLength" : 1
+          },
+          "vaults" : {
+            "type" : "array",
+            "uniqueItems" : true,
+            "items" : {
+              "$ref" : "#/components/schemas/NamedRef"
+            }
+          },
+          "config" : {
+            "type" : "object",
+            "additionalProperties" : { }
+          },
+          "predicate" : {
+            "$ref" : "#/components/schemas/PredicateDto"
+          }
+        }
+      },
+      "TransformResponse" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "integer",
+            "format" : "int64"
+          },
+          "name" : {
+            "type" : "string"
+          },
+          "description" : {
+            "type" : "string"
+          },
+          "type" : {
+            "type" : "string"
+          },
+          "schema" : {
+            "type" : "string"
+          },
+          "vaults" : {
+            "type" : "array",
+            "uniqueItems" : true,
+            "items" : {
+              "$ref" : "#/components/schemas/NamedRef"
+            }
+          },
+          "config" : {
+            "type" : "object",
+            "additionalProperties" : { }
+          },
+          "predicate" : {
+            "$ref" : "#/components/schemas/PredicateDto"
+          }
+        }
+      },
+      "Type" : {
+        "type" : "string",
+        "enum" : [ "ORACLE", "MYSQL", "MARIADB", "SQLSERVER", "POSTGRESQL", "MONGODB", "KAFKA", "REDIS", "KINESIS", "PUBSUB", "HTTP", "PULSAR", "EVENTHUBS", "NATS-STREAMING", "NATS-JETSTREAM", "PRAVEGA", "INFINISPAN", "ROCKETMQ", "RABBITMQ", "RABBITMQ_NATIVE_STREAM", "MILVUS", "QDRANT", "SQS", "JDBC" ]
+      },
+      "VaultRequest" : {
+        "type" : "object",
+        "required" : [ "name" ],
+        "properties" : {
+          "name" : {
+            "type" : "string",
+            "minLength" : 1
+          },
+          "plaintext" : {
+            "type" : "boolean"
+          },
+          "items" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "type" : "string"
+            }
+          }
+        }
+      },
+      "VaultResponse" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "integer",
+            "format" : "int64"
+          },
+          "name" : {
+            "type" : "string"
+          },
+          "plaintext" : {
+            "type" : "boolean"
+          },
+          "items" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "type" : "string"
+            }
+          }
+        }
+      },
+      "Visualization" : {
+        "type" : "object",
+        "properties" : {
+          "type" : {
+            "type" : "string"
+          },
+          "suggestedStep" : {
+            "type" : "string"
+          }
+        }
+      }
+    },
+    "securitySchemes" : {
+      "SecurityScheme" : {
+        "type" : "openIdConnect",
+        "openIdConnectUrl" : "https://keycloak.invalid/realms/none/.well-known/openid-configuration",
+        "description" : "Authentication"
+      }
+    }
+  },
+  "info" : {
+    "title" : "debezium-platform-conductor API",
+    "version" : "3.7.0-SNAPSHOT"
+  },
+  "servers" : [ {
+    "url" : "http://localhost:8080",
+    "description" : "Auto generated value"
+  }, {
+    "url" : "http://0.0.0.0:8080",
+    "description" : "Auto generated value"
+  } ]
+}

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -1,0 +1,1357 @@
+---
+openapi: 3.1.0
+paths:
+  /api/catalog:
+    get:
+      summary: Returns all available components for the current application version
+      parameters:
+      - name: type
+        in: query
+        schema:
+          type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+      tags:
+      - Catalog Resource
+  /api/catalog/{type}/{class}:
+    get:
+      summary: Returns descriptors for a specific component using current application
+        version
+      parameters:
+      - name: class
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: type
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+      tags:
+      - Catalog Resource
+  /api/catalog/{version}:
+    get:
+      summary: Returns all available components for a specific version
+      parameters:
+      - name: version
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: type
+        in: query
+        schema:
+          type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+      tags:
+      - Catalog Resource
+  /api/catalog/{version}/{type}/{class}:
+    get:
+      summary: Returns descriptors for a specific component
+      parameters:
+      - name: class
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: type
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: version
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+      tags:
+      - Catalog Resource
+  /api/connections:
+    post:
+      summary: Creates new connection
+      tags:
+      - connections
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ConnectionRequest"
+        required: true
+      responses:
+        "201":
+          content:
+            application/json:
+              schema:
+                type: string
+                format: uri
+        "400":
+          description: Bad Request
+    get:
+      summary: Returns all available connections
+      tags:
+      - connections
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/ConnectionResponse"
+  /api/connections/schemas:
+    get:
+      summary: Returns a list of JSON schema describing the required field for a Connection
+      tags:
+      - connections
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+  /api/connections/validate:
+    post:
+      summary: Verify that the connection is valid
+      tags:
+      - connections
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ConnectionRequest"
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  valid:
+                    type: boolean
+                  message:
+                    type: string
+                  errorType:
+                    type: string
+        "400":
+          description: Bad Request
+  /api/connections/{id}:
+    put:
+      summary: Updates an existing connection
+      tags:
+      - connections
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: integer
+          format: int64
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ConnectionRequest"
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ConnectionResponse"
+        "400":
+          description: Bad Request
+    get:
+      summary: Returns a connection with given id
+      tags:
+      - connections
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: integer
+          format: int64
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ConnectionResponse"
+    delete:
+      summary: Deletes an existing connection
+      tags:
+      - connections
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: integer
+          format: int64
+      responses:
+        "204": {}
+  /api/connections/{id}/collections:
+    get:
+      summary: Returns a list of collection names available on the source
+      tags:
+      - connections
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: integer
+          format: int64
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  catalogs:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/CatalogNode"
+  /api/destinations:
+    post:
+      summary: Creates new destination
+      tags:
+      - destinations
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/DestinationRequest"
+        required: true
+      responses:
+        "201":
+          content:
+            application/json:
+              schema:
+                type: string
+                format: uri
+        "400":
+          description: Bad Request
+    get:
+      summary: Returns all available destinations
+      tags:
+      - destinations
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/DestinationResponse"
+  /api/destinations/{id}:
+    put:
+      summary: Updates an existing destination
+      tags:
+      - destinations
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: integer
+          format: int64
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/DestinationRequest"
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DestinationResponse"
+        "400":
+          description: Bad Request
+    get:
+      summary: Returns a destination with given id
+      tags:
+      - destinations
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: integer
+          format: int64
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DestinationResponse"
+    delete:
+      summary: Deletes an existing destination
+      tags:
+      - destinations
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: integer
+          format: int64
+      responses:
+        "204": {}
+  /api/monitoring/panels:
+    get:
+      summary: List available monitoring panels
+      tags:
+      - Monitoring
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PanelsListResponse"
+  /api/monitoring/panels/{id}/query:
+    get:
+      summary: Query monitoring panel data for a specific pipeline
+      tags:
+      - Monitoring
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+      - description: End time (ISO 8601)
+        required: true
+        name: end
+        in: query
+        schema:
+          $ref: "#/components/schemas/Instant"
+      - description: Pipeline identifier
+        required: true
+        name: pipeline_id
+        in: query
+        schema:
+          type: string
+          pattern: "[a-zA-Z0-9_-]+"
+      - description: Start time (ISO 8601)
+        required: true
+        name: start
+        in: query
+        schema:
+          $ref: "#/components/schemas/Instant"
+      - description: "Query resolution step (e.g. 15s, 1m)"
+        name: step
+        in: query
+        schema:
+          type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PanelQueryResponse"
+        "400":
+          description: Invalid parameters
+          content:
+            application/json:
+              schema:
+                type: object
+        "404":
+          description: Panel not found
+          content:
+            application/json:
+              schema:
+                type: object
+  /api/pipelines:
+    post:
+      summary: Creates new pipeline
+      tags:
+      - pipelines
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PipelineRequest"
+        required: true
+      responses:
+        "201":
+          content:
+            application/json:
+              schema:
+                type: string
+                format: uri
+        "400":
+          description: Bad Request
+    get:
+      summary: Returns all available pipelines
+      tags:
+      - pipelines
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/PipelineResponse"
+  /api/pipelines/{id}:
+    put:
+      summary: Updates an existing pipeline
+      tags:
+      - pipelines
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: integer
+          format: int64
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PipelineUpdateRequest"
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PipelineResponse"
+        "400":
+          description: Bad Request
+    get:
+      summary: Returns a pipeline with given id
+      tags:
+      - pipelines
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: integer
+          format: int64
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PipelineResponse"
+    delete:
+      summary: Deletes an existing pipeline
+      tags:
+      - pipelines
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: integer
+          format: int64
+      responses:
+        "204": {}
+  /api/pipelines/{id}/logs:
+    get:
+      summary: Returns logs for pipeline with given id
+      tags:
+      - pipelines
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: integer
+          format: int64
+      responses:
+        "200":
+          description: OK
+          content:
+            text/plain:
+              schema:
+                type: string
+  /api/pipelines/{id}/signals:
+    post:
+      summary: Send signal to pipeline with given id
+      tags:
+      - pipelines
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: integer
+          format: int64
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SignalRequest"
+        required: true
+      responses:
+        "202":
+          description: Signal correctly sent to the pipeline
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SignalResponse"
+        "404":
+          description: Pipeline not found
+        "400":
+          description: Bad Request
+  /api/sources:
+    post:
+      summary: Creates new source
+      tags:
+      - sources
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SourceRequest"
+        required: true
+      responses:
+        "201":
+          content:
+            application/json:
+              schema:
+                type: string
+                format: uri
+        "400":
+          description: Bad Request
+    get:
+      summary: Returns all available sources
+      tags:
+      - sources
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/SourceResponse"
+  /api/sources/signals/verify:
+    post:
+      summary: Verify that signal data collection is configured correctly
+      tags:
+      - sources
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SignalCollectionVerifyRequest"
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  exists:
+                    type: boolean
+                  message:
+                    type: string
+        "400":
+          description: Bad Request
+  /api/sources/{id}:
+    put:
+      summary: Updates an existing source
+      tags:
+      - sources
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: integer
+          format: int64
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SourceRequest"
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SourceResponse"
+        "400":
+          description: Bad Request
+    get:
+      summary: Returns a source with given id
+      tags:
+      - sources
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: integer
+          format: int64
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SourceResponse"
+    delete:
+      summary: Deletes an existing source
+      tags:
+      - sources
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: integer
+          format: int64
+      responses:
+        "204": {}
+  /api/transforms:
+    post:
+      summary: Creates new transform
+      tags:
+      - transforms
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/TransformRequest"
+        required: true
+      responses:
+        "201":
+          content:
+            application/json:
+              schema:
+                type: string
+                format: uri
+        "400":
+          description: Bad Request
+    get:
+      summary: Returns all available transformations
+      tags:
+      - transforms
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/TransformResponse"
+  /api/transforms/{id}:
+    put:
+      summary: Updates an existing transform
+      tags:
+      - transforms
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: integer
+          format: int64
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/TransformRequest"
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TransformResponse"
+        "400":
+          description: Bad Request
+    get:
+      summary: Returns a transform with given id
+      tags:
+      - transforms
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: integer
+          format: int64
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TransformResponse"
+    delete:
+      summary: Deletes an existing transform
+      tags:
+      - transforms
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: integer
+          format: int64
+      responses:
+        "204": {}
+  /api/vaults:
+    post:
+      summary: Creates new vault
+      tags:
+      - vaults
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/VaultRequest"
+        required: true
+      responses:
+        "201":
+          content:
+            application/json:
+              schema:
+                type: string
+                format: uri
+        "400":
+          description: Bad Request
+    get:
+      summary: Returns all available vaults
+      tags:
+      - vaults
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/VaultResponse"
+  /api/vaults/{id}:
+    put:
+      summary: Updates an existing vault
+      tags:
+      - vaults
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: integer
+          format: int64
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/VaultRequest"
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/VaultResponse"
+        "400":
+          description: Bad Request
+    get:
+      summary: Returns a vault with given id
+      tags:
+      - vaults
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: integer
+          format: int64
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/VaultResponse"
+    delete:
+      summary: Deletes an existing vault
+      tags:
+      - vaults
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: integer
+          format: int64
+      responses:
+        "204": {}
+tags:
+- name: Monitoring
+  description: Pipeline monitoring and metrics
+- name: connections
+- name: destinations
+- name: pipelines
+- name: sources
+- name: transforms
+- name: vaults
+components:
+  schemas:
+    CatalogNode:
+      type: object
+      properties:
+        name:
+          type: string
+        schemas:
+          type: array
+          items:
+            $ref: "#/components/schemas/SchemaNode"
+        totalCollections:
+          type: integer
+          format: int32
+    CollectionNode:
+      type: object
+      properties:
+        name:
+          type: string
+        fullyQualifiedName:
+          type: string
+    ConnectionRequest:
+      type: object
+      required:
+      - name
+      - type
+      properties:
+        name:
+          type: string
+          minLength: 1
+        description:
+          type: string
+        type:
+          $ref: "#/components/schemas/Type"
+        config:
+          type: object
+          additionalProperties: {}
+    ConnectionResponse:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+        description:
+          type: string
+        type:
+          $ref: "#/components/schemas/Type"
+        config:
+          type: object
+          additionalProperties: {}
+    DestinationRequest:
+      type: object
+      required:
+      - name
+      - type
+      - schema
+      properties:
+        name:
+          type: string
+          minLength: 1
+        description:
+          type: string
+        type:
+          type: string
+          minLength: 1
+        schema:
+          type: string
+          minLength: 1
+        connection:
+          $ref: "#/components/schemas/NamedRef"
+        vaults:
+          type: array
+          uniqueItems: true
+          items:
+            $ref: "#/components/schemas/NamedRef"
+        config:
+          type: object
+          additionalProperties: {}
+    DestinationResponse:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+        description:
+          type: string
+        type:
+          type: string
+        schema:
+          type: string
+        connection:
+          $ref: "#/components/schemas/NamedRef"
+        vaults:
+          type: array
+          uniqueItems: true
+          items:
+            $ref: "#/components/schemas/NamedRef"
+        config:
+          type: object
+          additionalProperties: {}
+    Instant:
+      type: string
+      format: date-time
+      examples:
+      - 2022-03-10T16:15:50Z
+    Metadata:
+      type: object
+      properties:
+        queryDurationMs:
+          type: integer
+          format: int64
+    NamedRef:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+    PanelQueryResponse:
+      type: object
+      properties:
+        panelId:
+          type: string
+        pipelineId:
+          type: string
+        timeRange:
+          $ref: "#/components/schemas/TimeRange"
+        series:
+          type: array
+          items:
+            $ref: "#/components/schemas/TimeSeries"
+        metadata:
+          $ref: "#/components/schemas/Metadata"
+    PanelResponse:
+      type: object
+      properties:
+        id:
+          type: string
+        title:
+          type: string
+        description:
+          type: string
+        category:
+          type: string
+        unit:
+          type: string
+        visualization:
+          $ref: "#/components/schemas/Visualization"
+    PanelsListResponse:
+      type: object
+      properties:
+        panels:
+          type: array
+          items:
+            $ref: "#/components/schemas/PanelResponse"
+    PipelineRequest:
+      type: object
+      required:
+      - name
+      - source
+      - destination
+      - logLevel
+      properties:
+        name:
+          type: string
+          minLength: 1
+        description:
+          type: string
+        source:
+          $ref: "#/components/schemas/NamedRef"
+        destination:
+          $ref: "#/components/schemas/NamedRef"
+        transforms:
+          type: array
+          items:
+            $ref: "#/components/schemas/NamedRef"
+        logLevel:
+          type: string
+          minLength: 1
+        logLevels:
+          type: object
+          additionalProperties:
+            type: string
+    PipelineResponse:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+        description:
+          type: string
+        source:
+          $ref: "#/components/schemas/NamedRef"
+        destination:
+          $ref: "#/components/schemas/NamedRef"
+        transforms:
+          type: array
+          items:
+            $ref: "#/components/schemas/NamedRef"
+        logLevel:
+          type: string
+        logLevels:
+          type: object
+          additionalProperties:
+            type: string
+        status:
+          $ref: "#/components/schemas/PipelineStatus"
+        errorMessage:
+          type: string
+    PipelineStatus:
+      type: string
+      enum:
+      - DEPLOYING
+      - RUNNING
+      - STOPPED
+      - FAILED
+    PipelineUpdateRequest:
+      type: object
+      required:
+      - name
+      - logLevel
+      properties:
+        name:
+          type: string
+          minLength: 1
+        description:
+          type: string
+        transforms:
+          type: array
+          items:
+            $ref: "#/components/schemas/NamedRef"
+        logLevel:
+          type: string
+          minLength: 1
+        logLevels:
+          type: object
+          additionalProperties:
+            type: string
+    PredicateDto:
+      type: object
+      properties:
+        type:
+          type: string
+        config:
+          type: object
+          additionalProperties: {}
+        negate:
+          type: boolean
+    SchemaNode:
+      type: object
+      properties:
+        name:
+          type: string
+        collections:
+          type: array
+          items:
+            $ref: "#/components/schemas/CollectionNode"
+        collectionCount:
+          type: integer
+          format: int32
+    Signal:
+      type: object
+      properties:
+        id:
+          type: string
+    SignalCollectionVerifyRequest:
+      type: object
+      properties:
+        connectionId:
+          type: integer
+          format: int64
+        fullyQualifiedTableName:
+          type: string
+    SignalRequest:
+      type: object
+      required:
+      - id
+      - type
+      - data
+      properties:
+        id:
+          type: string
+          minLength: 1
+        type:
+          type: string
+          minLength: 1
+        data:
+          type: string
+          minLength: 1
+        additionalData:
+          type: object
+          additionalProperties: {}
+    SignalResponse:
+      type: object
+      properties:
+        signal:
+          $ref: "#/components/schemas/Signal"
+    SourceRequest:
+      type: object
+      required:
+      - name
+      - type
+      - schema
+      properties:
+        name:
+          type: string
+          minLength: 1
+        description:
+          type: string
+        type:
+          type: string
+          minLength: 1
+        schema:
+          type: string
+          minLength: 1
+        connection:
+          $ref: "#/components/schemas/NamedRef"
+        vaults:
+          type: array
+          uniqueItems: true
+          items:
+            $ref: "#/components/schemas/NamedRef"
+        config:
+          type: object
+          additionalProperties: {}
+    SourceResponse:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+        description:
+          type: string
+        type:
+          type: string
+        schema:
+          type: string
+        connection:
+          $ref: "#/components/schemas/NamedRef"
+        vaults:
+          type: array
+          uniqueItems: true
+          items:
+            $ref: "#/components/schemas/NamedRef"
+        config:
+          type: object
+          additionalProperties: {}
+    TimeRange:
+      type: object
+      properties:
+        start:
+          type: string
+        end:
+          type: string
+        step:
+          type: string
+    TimeSeries:
+      type: object
+      properties:
+        labels:
+          type: object
+          additionalProperties:
+            type: string
+        datapoints:
+          type: array
+          items:
+            type: array
+            items:
+              type: number
+              format: double
+    TransformRequest:
+      type: object
+      required:
+      - name
+      - type
+      - schema
+      properties:
+        name:
+          type: string
+          minLength: 1
+        description:
+          type: string
+        type:
+          type: string
+          minLength: 1
+        schema:
+          type: string
+          minLength: 1
+        vaults:
+          type: array
+          uniqueItems: true
+          items:
+            $ref: "#/components/schemas/NamedRef"
+        config:
+          type: object
+          additionalProperties: {}
+        predicate:
+          $ref: "#/components/schemas/PredicateDto"
+    TransformResponse:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+        description:
+          type: string
+        type:
+          type: string
+        schema:
+          type: string
+        vaults:
+          type: array
+          uniqueItems: true
+          items:
+            $ref: "#/components/schemas/NamedRef"
+        config:
+          type: object
+          additionalProperties: {}
+        predicate:
+          $ref: "#/components/schemas/PredicateDto"
+    Type:
+      type: string
+      enum:
+      - ORACLE
+      - MYSQL
+      - MARIADB
+      - SQLSERVER
+      - POSTGRESQL
+      - MONGODB
+      - KAFKA
+      - REDIS
+      - KINESIS
+      - PUBSUB
+      - HTTP
+      - PULSAR
+      - EVENTHUBS
+      - NATS-STREAMING
+      - NATS-JETSTREAM
+      - PRAVEGA
+      - INFINISPAN
+      - ROCKETMQ
+      - RABBITMQ
+      - RABBITMQ_NATIVE_STREAM
+      - MILVUS
+      - QDRANT
+      - SQS
+      - JDBC
+    VaultRequest:
+      type: object
+      required:
+      - name
+      properties:
+        name:
+          type: string
+          minLength: 1
+        plaintext:
+          type: boolean
+        items:
+          type: object
+          additionalProperties:
+            type: string
+    VaultResponse:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+        plaintext:
+          type: boolean
+        items:
+          type: object
+          additionalProperties:
+            type: string
+    Visualization:
+      type: object
+      properties:
+        type:
+          type: string
+        suggestedStep:
+          type: string
+  securitySchemes:
+    SecurityScheme:
+      type: openIdConnect
+      openIdConnectUrl: https://keycloak.invalid/realms/none/.well-known/openid-configuration
+      description: Authentication
+info:
+  title: debezium-platform-conductor API
+  version: 3.7.0-SNAPSHOT
+servers:
+- url: http://localhost:8080
+  description: Auto generated value
+- url: http://0.0.0.0:8080
+  description: Auto generated value


### PR DESCRIPTION
<!-- Make sure all your commits are signed before submitting your pull request -->
<!-- Run `git commit -s` to sign off your commits to satisfy the DCO check -->
<!-- Ensure your commit messages start with your GitHub issue, e.g., debezium/dbz#<issue_number> -->
Fixes debezium/dbz#2367

## Description
This pull request makes a configuration change to the application's OpenAPI documentation generation. The main change is the addition of a setting to specify where the OpenAPI schema files are stored.

OpenAPI documentation configuration:

* Added the `quarkus.smallrye-openapi.store-schema-directory` property to `application.yml` to store generated OpenAPI schemas in the `../openapi` directory.

## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [X] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [X] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [X] One feature/change per PR unless tightly coupled
- [X] Do a rebase on upstream `main`
