### PR TITLE
debezium/dbz#2395 Reject an OAuth2 private key that is not a data URI

### DIFF
--- a/debezium-platform-conductor/src/main/java/io/debezium/platform/environment/connection/destination/pulsar/OAuth2AuthHandler.java
+++ b/debezium-platform-conductor/src/main/java/io/debezium/platform/environment/connection/destination/pulsar/OAuth2AuthHandler.java
@@ -78,17 +78,17 @@ public class OAuth2AuthHandler implements PulsarAuthHandler {
         String privateKey = config.get("oauth2PrivateKey").toString();
         byte[] privateKeyBytes = null;
 
-        // indexOf returns -1 when the prefix is absent, and -1 + prefix.length() is a valid offset,
-        // so without this check the key is silently truncated by 28 characters instead of rejected.
-        int prefixIndex = privateKey.indexOf(PRIVATE_KEY_PREFIX);
-        if (prefixIndex < 0) {
-            LOGGER.warn("OAuth2 private key is not a data URI; expected it to contain '{}'", PRIVATE_KEY_PREFIX);
+        // The key has to START with the prefix, not merely contain it: anything pasted in front of
+        // it would otherwise pass validation here and only fail later when the Pulsar client builds
+        // its URI. Without any check at all the key is silently truncated by 28 characters.
+        if (!privateKey.startsWith(PRIVATE_KEY_PREFIX)) {
+            LOGGER.warn("OAuth2 private key is not a data URI; expected it to start with '{}'", PRIVATE_KEY_PREFIX);
             throw new IllegalArgumentException(
                     "OAuth2 Private Key must be a data URI of the form '" + PRIVATE_KEY_PREFIX + "<base64-encoded JSON credentials>'");
         }
 
         try {
-            String extracted = privateKey.substring(prefixIndex + PRIVATE_KEY_PREFIX.length());
+            String extracted = privateKey.substring(PRIVATE_KEY_PREFIX.length());
             privateKeyBytes = Base64.getDecoder().decode(extracted);
         }
         catch (IllegalArgumentException e) {
@@ -110,6 +110,5 @@ public class OAuth2AuthHandler implements PulsarAuthHandler {
             throw new IllegalArgumentException("OAuth2 Private Key JSON must contain both 'client_id' and 'client_secret' fields");
         }
 
-        String issuerUrl = config.get("oauth2IssuerUrl").toString();
     }
 }

--- a/debezium-platform-conductor/src/main/java/io/debezium/platform/environment/connection/destination/pulsar/OAuth2AuthHandler.java
+++ b/debezium-platform-conductor/src/main/java/io/debezium/platform/environment/connection/destination/pulsar/OAuth2AuthHandler.java
@@ -25,6 +25,9 @@ public class OAuth2AuthHandler implements PulsarAuthHandler {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(OAuth2AuthHandler.class);
 
+    /** Format as per the Pulsar doc -> data:application/json;base64,WaVf/RB7ZAW7pMG3rhxnL3zC2QFqyyLaKl5W6JwWdhw= */
+    private static final String PRIVATE_KEY_PREFIX = "data:application/json;base64,";
+
     /**
      * Configures the provided {@link PulsarAdminBuilder} with the authentication settings
      * required by this handler.
@@ -75,10 +78,17 @@ public class OAuth2AuthHandler implements PulsarAuthHandler {
         String privateKey = config.get("oauth2PrivateKey").toString();
         byte[] privateKeyBytes = null;
 
+        // indexOf returns -1 when the prefix is absent, and -1 + prefix.length() is a valid offset,
+        // so without this check the key is silently truncated by 28 characters instead of rejected.
+        int prefixIndex = privateKey.indexOf(PRIVATE_KEY_PREFIX);
+        if (prefixIndex < 0) {
+            LOGGER.warn("OAuth2 private key is not a data URI; expected it to contain '{}'", PRIVATE_KEY_PREFIX);
+            throw new IllegalArgumentException(
+                    "OAuth2 Private Key must be a data URI of the form '" + PRIVATE_KEY_PREFIX + "<base64-encoded JSON credentials>'");
+        }
+
         try {
-            // Format as per the Pulsar doc -> data:application/json;base64,WaVf/RB7ZAW7pMG3rhxnL3zC2QFqyyLaKl5W6JwWdhw=
-            String prefix = "data:application/json;base64,";
-            String extracted = privateKey.substring(privateKey.indexOf(prefix) + prefix.length());
+            String extracted = privateKey.substring(prefixIndex + PRIVATE_KEY_PREFIX.length());
             privateKeyBytes = Base64.getDecoder().decode(extracted);
         }
         catch (IllegalArgumentException e) {

--- a/debezium-platform-conductor/src/test/java/io/debezium/platform/environment/connection/pulsar/OAuth2AuthHandlerTest.java
+++ b/debezium-platform-conductor/src/test/java/io/debezium/platform/environment/connection/pulsar/OAuth2AuthHandlerTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.platform.environment.connection.pulsar;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import io.debezium.platform.environment.connection.destination.pulsar.OAuth2AuthHandler;
+
+public class OAuth2AuthHandlerTest {
+
+    private static final String PREFIX = "data:application/json;base64,";
+    private static final String CREDENTIALS = "{\"client_id\":\"admin\",\"client_secret\":\"s3cret\"}";
+    private static final String ISSUER_URL = "http://issuer.example.com";
+
+    private OAuth2AuthHandler handler;
+
+    @BeforeEach
+    void setUp() {
+        handler = new OAuth2AuthHandler();
+    }
+
+    private static String base64(String value) {
+        return Base64.getEncoder().encodeToString(value.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private static Map<String, Object> config(String privateKey) {
+        return Map.of("oauth2PrivateKey", privateKey, "oauth2IssuerUrl", ISSUER_URL);
+    }
+
+    @Test
+    @DisplayName("Should validate a private key supplied as a data URI")
+    void shouldValidateDataUriPrivateKey() {
+        assertDoesNotThrow(() -> handler.validate(config(PREFIX + base64(CREDENTIALS))));
+    }
+
+    @Test
+    @DisplayName("Should reject a private key that is not a data URI, even when the remainder decodes to valid credentials")
+    void shouldRejectPrivateKeyWithoutDataUriPrefix() {
+        // Bare base64, no "data:application/json;base64," prefix. The first 28 characters are
+        // padding, so slicing them off leaves a perfectly decodable credentials document — which
+        // is exactly why this has to be rejected on the prefix rather than on what decodes.
+        String bare = base64("X".repeat(21) + CREDENTIALS);
+
+        assertThrows(IllegalArgumentException.class, () -> handler.validate(config(bare)));
+    }
+
+    @Test
+    @DisplayName("Should reject a private key shorter than the data URI prefix with IllegalArgumentException")
+    void shouldRejectPrivateKeyShorterThanPrefix() {
+        assertThrows(IllegalArgumentException.class, () -> handler.validate(config("abc")));
+    }
+
+    @Test
+    @DisplayName("Should reject a data URI whose payload is not valid Base64")
+    void shouldRejectNonBase64Payload() {
+        assertThrows(IllegalArgumentException.class, () -> handler.validate(config(PREFIX + "not*valid*base64")));
+    }
+
+    @Test
+    @DisplayName("Should reject a data URI whose payload does not decode to JSON")
+    void shouldRejectPayloadThatIsNotJson() {
+        assertThrows(IllegalArgumentException.class, () -> handler.validate(config(PREFIX + base64("plain text"))));
+    }
+
+    @Test
+    @DisplayName("Should reject credentials missing client_id or client_secret")
+    void shouldRejectCredentialsMissingRequiredFields() {
+        assertThrows(IllegalArgumentException.class,
+                () -> handler.validate(config(PREFIX + base64("{\"client_id\":\"admin\"}"))));
+        assertThrows(IllegalArgumentException.class,
+                () -> handler.validate(config(PREFIX + base64("{\"client_secret\":\"s3cret\"}"))));
+    }
+
+    @Test
+    @DisplayName("Should fail validation when the private key or issuer url is missing")
+    void shouldFailWhenRequiredValuesAreMissing() {
+        assertThrows(IllegalArgumentException.class,
+                () -> handler.validate(Map.of("oauth2IssuerUrl", ISSUER_URL)));
+        assertThrows(IllegalArgumentException.class,
+                () -> handler.validate(Map.of("oauth2PrivateKey", PREFIX + base64(CREDENTIALS))));
+    }
+}

--- a/debezium-platform-conductor/src/test/java/io/debezium/platform/environment/connection/pulsar/OAuth2AuthHandlerTest.java
+++ b/debezium-platform-conductor/src/test/java/io/debezium/platform/environment/connection/pulsar/OAuth2AuthHandlerTest.java
@@ -57,6 +57,16 @@ public class OAuth2AuthHandlerTest {
     }
 
     @Test
+    @DisplayName("Should reject a data URI with anything pasted in front of the prefix")
+    void shouldRejectPrivateKeyWithTextBeforeThePrefix() {
+        // A contains-check would accept this and let it through to the Pulsar client, which then
+        // fails while building its URI. The prefix has to be at position 0.
+        String prefixedWithJunk = "junk" + PREFIX + base64(CREDENTIALS);
+
+        assertThrows(IllegalArgumentException.class, () -> handler.validate(config(prefixedWithJunk)));
+    }
+
+    @Test
     @DisplayName("Should reject a private key shorter than the data URI prefix with IllegalArgumentException")
     void shouldRejectPrivateKeyShorterThanPrefix() {
         assertThrows(IllegalArgumentException.class, () -> handler.validate(config("abc")));


### PR DESCRIPTION
Closes debezium/dbz#2395.

## What

`OAuth2AuthHandler.validate` did not check that the OAuth2 private key is a `data:application/json;base64,` URI before slicing the prefix off it. `indexOf` returns `-1` when the prefix is absent, and `-1 + prefix.length()` is a valid offset, so a bare base64 key was **silently truncated by 28 characters** and then decoded — rather than being reported as the wrong shape.

The validator now requires the prefix at position 0.

## Scope, stated accurately

An earlier version of this description said an invalid key was simply accepted. @pxcamus tested it against a live Pulsar instance and showed that is not the whole story: such a connection *is* eventually marked invalid, because the Pulsar client rejects it while building its URI. The accurate framing is therefore narrower —

- the key passes **this** validator, whose job is to catch exactly this
- the failure surfaces later, from inside the Pulsar client, as a less obvious error
- for a bare base64 key the 28-character truncation happens first, so what gets reported is a decode/JSON failure rather than "this is not a data URI"

So this is a diagnosability fix, not a "bad credentials are accepted" fix.

## Also

Drops the dead `issuerUrl` assignment at the end of `validate()` — it was the last statement in the method and the value was never read. Included here at review request, since the branch needed a force-push anyway.

## Tests

`OAuth2AuthHandlerTest`, 8 cases. The ones that fail without the fix:

| case | why it matters |
|---|---|
| bare base64 whose first 28 chars are padding | the remainder decodes to perfectly valid credentials, so it has to be rejected on the **prefix**, not on what decodes |
| `"junk" + prefix + valid base64` | a contains-check accepts this; it must be rejected at position 0 |
| key shorter than the prefix | the original truncation case |

The other five pin existing behaviour — non-base64 payload, payload that is not JSON, credentials missing `client_id`/`client_secret`, missing config values, and the happy path — and pass before and after.

Run with JDK 22: `Tests run: 8, Failures: 0`.
