### PR TITLE
debezium/dbz#2385 Restore and improve Smart Editor in source and dest…

### DIFF
--- a/debezium-platform-stage/cypress/e2e/destination.cy.ts
+++ b/debezium-platform-stage/cypress/e2e/destination.cy.ts
@@ -183,7 +183,7 @@ describe('Destination Management', () => {
     it('should open smart editor from catalog when no connector is chosen', () => {
       cy.get('[data-tour="destination-catalog-smart-editor"]').click({ force: true });
       cy.url().should('match', /\/destination\/create_destination\/?$/);
-      cy.contains('No connector selected').should('be.visible');
+      cy.get('.smartEditor').should('be.visible');
     });
 
     it('should load catalog from GET /api/catalog', () => {

--- a/debezium-platform-stage/cypress/e2e/source.cy.ts
+++ b/debezium-platform-stage/cypress/e2e/source.cy.ts
@@ -247,7 +247,7 @@ describe('Source Management', () => {
       cy.visitWithTourDisabled('/source/catalog');
       cy.contains('button', 'Create using smart editor').click({ force: true });
       cy.url().should('match', /\/source\/create_source\/?$/);
-      cy.contains('No connector selected').should('be.visible');
+      cy.get('.smartEditor').should('be.visible');
     });
   });
 

--- a/debezium-platform-stage/src/__test__/unit/test-utils.tsx
+++ b/debezium-platform-stage/src/__test__/unit/test-utils.tsx
@@ -16,6 +16,7 @@ import { QueryClient, QueryClientProvider } from "react-query";
 import { GuidedTourProvider } from "../../components/GuidedTourContext";
 import { DocHelpProvider } from "../../components/DocHelpContext";
 import { NotificationProvider } from "../../appLayout/AppNotificationContext";
+import { AppContextProvider } from "../../appLayout/AppContext";
 
 import commonEN from "../../../public/locales/en/common.json";
 import pipelineEN from "../../../public/locales/en/pipeline.json";
@@ -101,7 +102,9 @@ function render(
           <NotificationProvider>
             <GuidedTourProvider>
               <DocHelpProvider>
-                <I18nextProvider i18n={i18n}>{children}</I18nextProvider>
+                <AppContextProvider>
+                  <I18nextProvider i18n={i18n}>{children}</I18nextProvider>
+                </AppContextProvider>
               </DocHelpProvider>
             </GuidedTourProvider>
           </NotificationProvider>

--- a/debezium-platform-stage/src/pages/Destination/CreateDestination.tsx
+++ b/debezium-platform-stage/src/pages/Destination/CreateDestination.tsx
@@ -14,7 +14,6 @@ import { useRef, useState } from "react";
 import { createPost, Payload, Destination } from "../../apis/apis";
 import { API_URL } from "../../utils/constants";
 import { useNotification } from "../../appLayout/AppNotificationContext";
-import PageHeader from "@components/PageHeader";
 import { useTranslation } from "react-i18next";
 import { useQuery } from "react-query";
 import { fetchData } from "../../apis/apis";
@@ -22,17 +21,22 @@ import { ConnectorSchema } from "../../apis/types";
 import CreateSchemaForm, {
   CreateSchemaFormHandle,
 } from "@components/CreateSchemaForm";
+import { PageHeader } from "@patternfly/react-component-groups";
+import { CodeEditor, Language } from "@patternfly/react-code-editor";
+import { detectAndParseFormat } from "../../utils/formatCodeUtils";
+import { useData } from "@appContext/AppContext";
+import style from "../../styles/createConnector.module.css";
 
-export interface ICreateDestinationProps {
+interface CreateDestinationProps {
   modelLoaded?: boolean;
   selectedId?: string;
   selectDestination?: (destinationId: string) => void;
-  onSelection?: (destination: Destination) => void;
+  onSelection?: (selection: Destination) => void;
 }
 
-const CreateDestination: React.FunctionComponent<ICreateDestinationProps> = ({
-  modelLoaded,
-  selectedId,
+const CreateDestination: React.FunctionComponent<CreateDestinationProps> = ({
+  modelLoaded = false,
+  selectedId = "",
   selectDestination,
   onSelection,
 }) => {
@@ -40,6 +44,7 @@ const CreateDestination: React.FunctionComponent<ICreateDestinationProps> = ({
   const location = useLocation();
   const { t } = useTranslation();
   const { addNotification } = useNotification();
+  const { darkMode } = useData();
 
   const destinationIdParam = useParams<{ destinationId: string }>();
   const destinationId = modelLoaded ? selectedId : destinationIdParam.destinationId;
@@ -48,6 +53,9 @@ const CreateDestination: React.FunctionComponent<ICreateDestinationProps> = ({
 
   const [isLoading, setIsLoading] = useState(false);
   const formRef = useRef<CreateSchemaFormHandle>(null);
+
+  const editorSelected = destinationId ? "form-editor" : "smart-editor";
+  const [codeText, setCodeText] = useState<string>("");
 
   const descriptorPath = React.useMemo(() => {
     if (descriptor) return descriptor.replace(/\.json$/, "");
@@ -74,6 +82,10 @@ const CreateDestination: React.FunctionComponent<ICreateDestinationProps> = ({
     return Array.isArray(destinations) ? destinations.map((d) => d.name) : [];
   }, [destinations]);
 
+  const handleCodeChange = (value: string) => {
+    setCodeText(value);
+  };
+
   const createNewDestination = async (payload: Record<string, unknown>) => {
     setIsLoading(true);
     const response = await createPost(
@@ -98,50 +110,102 @@ const CreateDestination: React.FunctionComponent<ICreateDestinationProps> = ({
     setIsLoading(false);
   };
 
-  const renderContent = () => {
-    if (!destinationId) {
-      return (
-        <Alert variant="warning" isInline title="No connector selected">
-          Please select a connector from the catalog first.
-        </Alert>
+  const handleSubmitCode = () => {
+    try {
+      const finalPayload = detectAndParseFormat(codeText, "destination");
+
+      if (!finalPayload || !finalPayload.name?.trim()) {
+        addNotification("danger", "Validation failed", "Connector name is required.");
+        return;
+      }
+      if (!finalPayload.type?.trim()) {
+        addNotification("danger", "Validation failed", "Connector type is required.");
+        return;
+      }
+
+      // Verify uniqueness of name
+      if (existingDestinations.includes(finalPayload.name.trim())) {
+        addNotification(
+          "danger",
+          "Validation failed",
+          `Destination with name '${finalPayload.name.trim()}' already exists.`
+        );
+        return;
+      }
+
+      createNewDestination(finalPayload);
+    } catch (e: unknown) {
+      addNotification(
+        "danger",
+        "Validation failed",
+        `Invalid configuration: ${(e as Error).message || "Invalid syntax"}`
       );
     }
+  };
 
-    if (isSchemaLoading) {
+  const renderContent = () => {
+    if (editorSelected === "form-editor") {
+      if (!destinationId) {
+        return (
+          <Alert variant="warning" isInline title={t("common:emptyState.title", { val: t("destination:destination") })}>
+            Please select a connector from the catalog first.
+          </Alert>
+        );
+      }
+
+      if (isSchemaLoading) {
+        return (
+          <div>
+            <Skeleton fontSize="2xl" width="40%" />
+            <br />
+            <Skeleton fontSize="md" width="60%" />
+            <br />
+            <Skeleton fontSize="md" width="80%" />
+            <br />
+            <Skeleton fontSize="md" width="50%" />
+          </div>
+        );
+      }
+
+      if (schemaError) {
+        return (
+          <Alert variant="danger" isInline title="Failed to load connector schema">
+            {schemaError.message}
+          </Alert>
+        );
+      }
+
+      if (!connectorSchema) return null;
+
       return (
-        <div>
-          <Skeleton fontSize="2xl" width="40%" />
-          <br />
-          <Skeleton fontSize="md" width="60%" />
-          <br />
-          <Skeleton fontSize="md" width="80%" />
-          <br />
-          <Skeleton fontSize="md" width="50%" />
+        <CreateSchemaForm
+          ref={formRef}
+          connectorSchema={connectorSchema}
+          destinationId={destinationId}
+          onSubmit={createNewDestination}
+          existingNames={existingDestinations}
+          {...(modelLoaded ? { defaultLayoutMode: "tabs" as const } : {})}
+        />
+      );
+    } else {
+      return (
+        <div className={`${style.smartEditor} smartEditor`}>
+          <CodeEditor
+            isUploadEnabled
+            isDownloadEnabled
+            isCopyEnabled
+            isLanguageLabelVisible
+            isMinimapVisible
+            isDarkTheme={darkMode}
+            language={codeText.trim().startsWith("{") || codeText.trim().startsWith("[") ? Language.json : Language.plaintext}
+            downloadFileName="destination-config"
+            isFullHeight
+            code={codeText}
+            onCodeChange={handleCodeChange}
+          />
         </div>
       );
     }
-
-    if (schemaError) {
-      return (
-        <Alert variant="danger" isInline title="Failed to load connector schema">
-          {schemaError.message}
-        </Alert>
-      );
-    }
-
-    if (!connectorSchema) return null;
-
-    return (
-      <CreateSchemaForm
-        ref={formRef}
-        connectorSchema={connectorSchema}
-        destinationId={destinationId}
-        onSubmit={createNewDestination}
-        existingNames={existingDestinations}
-        hideSignalCollections={true}
-        {...(modelLoaded ? { defaultLayoutMode: "tabs" as const } : {})}
-      />
-    );
   };
 
   return (
@@ -149,7 +213,7 @@ const CreateDestination: React.FunctionComponent<ICreateDestinationProps> = ({
       {!modelLoaded && (
         <PageHeader
           title={t("destination:create.title")}
-          description={t("destination:create.description")}
+          subtitle={t("destination:create.description")}
         />
       )}
 
@@ -171,11 +235,15 @@ const CreateDestination: React.FunctionComponent<ICreateDestinationProps> = ({
               <Button
                 variant="primary"
                 isLoading={isLoading}
-                isDisabled={isLoading || isSchemaLoading || !!schemaError}
+                isDisabled={isLoading || (editorSelected === "form-editor" && (isSchemaLoading || !!schemaError))}
                 type={ButtonType.submit}
                 onClick={(e) => {
                   e.preventDefault();
-                  formRef.current?.submit();
+                  if (editorSelected === "form-editor") {
+                    formRef.current?.submit();
+                  } else {
+                    handleSubmitCode();
+                  }
                 }}
               >
                 {t("destination:create.title")}

--- a/debezium-platform-stage/src/pages/Source/CreateSource.test.tsx
+++ b/debezium-platform-stage/src/pages/Source/CreateSource.test.tsx
@@ -47,19 +47,16 @@ describe("CreateSource", () => {
     } as any);
   });
 
-  it("shows inline warning when no connector is selected", () => {
+  it("renders smart editor when no connector is selected", () => {
     vi.mocked(useQuery).mockReturnValue({
       data: undefined,
       error: null,
       isLoading: false,
     } as any);
 
-    render(<CreateSource />);
+    const { container } = render(<CreateSource />);
 
-    expect(screen.getByText("No connector selected")).toBeInTheDocument();
-    expect(
-      screen.getByText("Please select a connector from the catalog first."),
-    ).toBeInTheDocument();
+    expect(container.querySelector(".smartEditor")).toBeInTheDocument();
   });
 
   it("shows schema error alert when catalog schema fails to load", () => {

--- a/debezium-platform-stage/src/pages/Source/CreateSource.tsx
+++ b/debezium-platform-stage/src/pages/Source/CreateSource.tsx
@@ -22,6 +22,10 @@ import CreateSchemaForm, {
   CreateSchemaFormHandle,
 } from "@components/CreateSchemaForm";
 import { PageHeader } from "@patternfly/react-component-groups";
+import { CodeEditor, Language } from "@patternfly/react-code-editor";
+import { detectAndParseFormat } from "../../utils/formatCodeUtils";
+import { useData } from "@appContext/AppContext";
+import style from "../../styles/createConnector.module.css";
 
 interface CreateSourceProps {
   modelLoaded?: boolean;
@@ -31,8 +35,8 @@ interface CreateSourceProps {
 }
 
 const CreateSource: React.FunctionComponent<CreateSourceProps> = ({
-  modelLoaded,
-  selectedId,
+  modelLoaded = false,
+  selectedId = "",
   selectSource,
   onSelection,
 }) => {
@@ -40,6 +44,7 @@ const CreateSource: React.FunctionComponent<CreateSourceProps> = ({
   const location = useLocation();
   const { t } = useTranslation();
   const { addNotification } = useNotification();
+  const { darkMode } = useData();
 
   const sourceIdParam = useParams<{ sourceId: string }>();
   const sourceId = modelLoaded ? selectedId : sourceIdParam.sourceId;
@@ -48,6 +53,9 @@ const CreateSource: React.FunctionComponent<CreateSourceProps> = ({
 
   const [isLoading, setIsLoading] = useState(false);
   const formRef = useRef<CreateSchemaFormHandle>(null);
+
+  const editorSelected = sourceId ? "form-editor" : "smart-editor";
+  const [codeText, setCodeText] = useState<string>("");
 
   const descriptorPath = React.useMemo(() => {
     if (descriptor) return descriptor.replace(/\.json$/, "");
@@ -74,6 +82,10 @@ const CreateSource: React.FunctionComponent<CreateSourceProps> = ({
     return Array.isArray(sources) ? sources.map((s) => s.name) : [];
   }, [sources]);
 
+  const handleCodeChange = (value: string) => {
+    setCodeText(value);
+  };
+
   const createNewSource = async (payload: Record<string, unknown>) => {
     setIsLoading(true);
     const response = await createPost(
@@ -98,49 +110,102 @@ const CreateSource: React.FunctionComponent<CreateSourceProps> = ({
     setIsLoading(false);
   };
 
-  const renderContent = () => {
-    if (!sourceId) {
-      return (
-        <Alert variant="warning" isInline title="No connector selected">
-          Please select a connector from the catalog first.
-        </Alert>
+  const handleSubmitCode = () => {
+    try {
+      const finalPayload = detectAndParseFormat(codeText, "source");
+
+      if (!finalPayload || !finalPayload.name?.trim()) {
+        addNotification("danger", "Validation failed", "Connector name is required.");
+        return;
+      }
+      if (!finalPayload.type?.trim()) {
+        addNotification("danger", "Validation failed", "Connector type is required.");
+        return;
+      }
+
+      // Verify uniqueness of name
+      if (existingSources.includes(finalPayload.name.trim())) {
+        addNotification(
+          "danger",
+          "Validation failed",
+          `Source with name '${finalPayload.name.trim()}' already exists.`
+        );
+        return;
+      }
+
+      createNewSource(finalPayload);
+    } catch (e: unknown) {
+      addNotification(
+        "danger",
+        "Validation failed",
+        `Invalid configuration: ${(e as Error).message || "Invalid syntax"}`
       );
     }
+  };
 
-    if (isSchemaLoading) {
+  const renderContent = () => {
+    if (editorSelected === "form-editor") {
+      if (!sourceId) {
+        return (
+          <Alert variant="warning" isInline title={t("common:emptyState.title", { val: t("source:source") })}>
+            Please select a connector from the catalog first.
+          </Alert>
+        );
+      }
+
+      if (isSchemaLoading) {
+        return (
+          <div>
+            <Skeleton fontSize="2xl" width="40%" />
+            <br />
+            <Skeleton fontSize="md" width="60%" />
+            <br />
+            <Skeleton fontSize="md" width="80%" />
+            <br />
+            <Skeleton fontSize="md" width="50%" />
+          </div>
+        );
+      }
+
+      if (schemaError) {
+        return (
+          <Alert variant="danger" isInline title="Failed to load connector schema">
+            {schemaError.message}
+          </Alert>
+        );
+      }
+
+      if (!connectorSchema) return null;
+
       return (
-        <div>
-          <Skeleton fontSize="2xl" width="40%" />
-          <br />
-          <Skeleton fontSize="md" width="60%" />
-          <br />
-          <Skeleton fontSize="md" width="80%" />
-          <br />
-          <Skeleton fontSize="md" width="50%" />
+        <CreateSchemaForm
+          ref={formRef}
+          connectorSchema={connectorSchema}
+          sourceId={sourceId}
+          onSubmit={createNewSource}
+          existingNames={existingSources}
+          {...(modelLoaded ? { defaultLayoutMode: "tabs" as const } : {})}
+        />
+      );
+    } else {
+      return (
+        <div className={`${style.smartEditor} smartEditor`}>
+          <CodeEditor
+            isUploadEnabled
+            isDownloadEnabled
+            isCopyEnabled
+            isLanguageLabelVisible
+            isMinimapVisible
+            isDarkTheme={darkMode}
+            language={codeText.trim().startsWith("{") || codeText.trim().startsWith("[") ? Language.json : Language.plaintext}
+            downloadFileName="source-config"
+            isFullHeight
+            code={codeText}
+            onCodeChange={handleCodeChange}
+          />
         </div>
       );
     }
-
-    if (schemaError) {
-      return (
-        <Alert variant="danger" isInline title="Failed to load connector schema">
-          {schemaError.message}
-        </Alert>
-      );
-    }
-
-    if (!connectorSchema) return null;
-
-    return (
-      <CreateSchemaForm
-        ref={formRef}
-        connectorSchema={connectorSchema}
-        sourceId={sourceId}
-        onSubmit={createNewSource}
-        existingNames={existingSources}
-        {...(modelLoaded ? { defaultLayoutMode: "tabs" as const } : {})}
-      />
-    );
   };
 
   return (
@@ -149,7 +214,6 @@ const CreateSource: React.FunctionComponent<CreateSourceProps> = ({
         <PageHeader
           title={t("source:create.title")}
           subtitle={t("source:create.description")}
-
         />
       )}
 
@@ -171,11 +235,15 @@ const CreateSource: React.FunctionComponent<CreateSourceProps> = ({
               <Button
                 variant="primary"
                 isLoading={isLoading}
-                isDisabled={isLoading || isSchemaLoading || !!schemaError}
+                isDisabled={isLoading || (editorSelected === "form-editor" && (isSchemaLoading || !!schemaError))}
                 type={ButtonType.submit}
                 onClick={(e) => {
                   e.preventDefault();
-                  formRef.current?.submit();
+                  if (editorSelected === "form-editor") {
+                    formRef.current?.submit();
+                  } else {
+                    handleSubmitCode();
+                  }
                 }}
               >
                 {t("source:create.title")}

--- a/debezium-platform-stage/src/styles/createConnector.module.css
+++ b/debezium-platform-stage/src/styles/createConnector.module.css
@@ -23,4 +23,5 @@
 .smartEditor {
     flex: 1 1 auto;
     min-height: 0;
-  }
+    height: 100%;
+}

--- a/debezium-platform-stage/src/utils/formatCodeUtils.test.ts
+++ b/debezium-platform-stage/src/utils/formatCodeUtils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { extractTransformsAndPredicates, formatCode } from "./formatCodeUtils";
+import { extractTransformsAndPredicates, formatCode, detectAndParseFormat } from "./formatCodeUtils";
 import type { Payload } from "src/apis";
 
 describe("formatCode", () => {
@@ -28,18 +28,71 @@ describe("formatCode", () => {
 # header
 debezium.source.connector.class = io.debezium.connector.mysql.MySqlConnector
 debezium.source.database.hostname = localhost
+debezium.source.name = my-postgres-source
+debezium.source.description = My postgres source
 `;
     const out = formatCode("source", "properties-file", raw);
     expect(out.type).toBe("io.debezium.connector.mysql.MySqlConnector");
+    expect(out.name).toBe("my-postgres-source");
+    expect(out.description).toBe("My postgres source");
     expect(out.config).toEqual({ "database.hostname": "localhost" });
   });
 
   it("parses properties-file for destination", () => {
     const raw = `debezium.sink.type = kafka
-debezium.sink.topics = orders`;
+debezium.sink.topics = orders
+debezium.sink.name = my-dest
+debezium.sink.description = My dest`;
     const out = formatCode("destination", "properties-file", raw);
     expect(out.type).toBe("kafka");
+    expect(out.name).toBe("my-dest");
+    expect(out.description).toBe("My dest");
     expect(out.config).toEqual({ topics: "orders" });
+  });
+});
+
+describe("detectAndParseFormat", () => {
+  it("auto-detects Kafka Connect JSON format", () => {
+    const raw = JSON.stringify({
+      name: "kafka-src",
+      config: {
+        "connector.class": "io.debezium.connector.postgresql.PostgresConnector",
+        "database.hostname": "localhost",
+      },
+    });
+    const out = detectAndParseFormat(raw, "source");
+    expect(out.name).toBe("kafka-src");
+    expect(out.type).toBe("io.debezium.connector.postgresql.PostgresConnector");
+    expect(out.config).toEqual({ "database.hostname": "localhost" });
+  });
+
+  it("auto-detects Platform JSON format", () => {
+    const raw = JSON.stringify({
+      name: "plat-src",
+      type: "io.debezium.connector.mysql.MySqlConnector",
+      config: { "database.port": "3306" },
+    });
+    const out = detectAndParseFormat(raw, "source");
+    expect(out.name).toBe("plat-src");
+    expect(out.type).toBe("io.debezium.connector.mysql.MySqlConnector");
+    expect(out.config).toEqual({ "database.port": "3306" });
+  });
+
+  it("auto-detects Debezium Server Properties format", () => {
+    const raw = `
+debezium.source.connector.class=io.debezium.connector.mysql.MySqlConnector
+debezium.source.name=prop-src
+debezium.source.database.hostname=dbhost
+`;
+    const out = detectAndParseFormat(raw, "source");
+    expect(out.name).toBe("prop-src");
+    expect(out.type).toBe("io.debezium.connector.mysql.MySqlConnector");
+    expect(out.config).toEqual({ "database.hostname": "dbhost" });
+  });
+
+  it("throws error when code is empty or invalid format", () => {
+    expect(() => detectAndParseFormat("", "source")).toThrow("Configuration code is empty");
+    expect(() => detectAndParseFormat("invalid text without equals", "source")).toThrow();
   });
 });
 

--- a/debezium-platform-stage/src/utils/formatCodeUtils.ts
+++ b/debezium-platform-stage/src/utils/formatCodeUtils.ts
@@ -30,27 +30,36 @@ export function formatCode(connectorType: "source" | "destination", formatType: 
             const match = trimmed.match(/^\s*([a-zA-Z0-9._-]+)\s*=\s*(.*)$/);
             if (match) {
                 const key = match[1];
-                const value = match[2];
+                const value = match[2].trim();
                 if (connectorType === "source") {
                     if (key === "debezium.source.connector.class") {
                         connectorClass = value;
                     } else if (key.startsWith("debezium.source.")) {
                         config[key.replace("debezium.source.", "")] = value;
+                    } else if (key === "name" || key === "description") {
+                        config[key] = value;
                     }
                 } else {
                     if (key === "debezium.sink.type") {
                         connectorClass = value;
                     } else if (key.startsWith("debezium.sink.")) {
                         config[key.replace("debezium.sink.", "")] = value;
+                    } else if (key === "name" || key === "description") {
+                        config[key] = value;
                     }
                 }
 
             }
         }
 
+        const name = config.name || "";
+        const description = config.description || "";
+        delete config.name;
+        delete config.description;
+
         formattedCode = {
-            name: "",
-            description: "",
+            name,
+            description,
             type: connectorClass,
             schema: "schema123",
             vaults: [],
@@ -58,6 +67,59 @@ export function formatCode(connectorType: "source" | "destination", formatType: 
         };
     }
     return formattedCode;
+}
+
+export function detectAndParseFormat(
+    codeText: string,
+    connectorType: "source" | "destination"
+): Payload {
+    if (!codeText || !codeText.trim()) {
+        throw new Error("Configuration code is empty");
+    }
+
+    const trimmed = codeText.trim();
+
+    // 1. Check if input is JSON
+    if (trimmed.startsWith("{") || trimmed.startsWith("[")) {
+        try {
+            const parsed = JSON.parse(trimmed);
+            if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+                // Check if it's Kafka Connect JSON format (has a config object containing connector.class or debezium.sink.type)
+                if (
+                    parsed.config &&
+                    typeof parsed.config === "object" &&
+                    (parsed.config["connector.class"] || parsed.config["debezium.sink.type"])
+                ) {
+                    return formatCode(connectorType, "kafka-connect", parsed);
+                }
+
+                // Otherwise, treat as Platform JSON payload format
+                return {
+                    name: parsed.name || "",
+                    description: parsed.description || "",
+                    type: parsed.type || "",
+                    schema: parsed.schema || "schema123",
+                    vaults: parsed.vaults || [],
+                    config: parsed.config || {},
+                };
+            }
+        } catch (e: unknown) {
+            throw new Error(`JSON syntax error: ${(e as Error).message || "Invalid JSON"}`);
+        }
+    }
+
+    // 2. Treat as Debezium Server Properties File (key=value lines)
+    const lines = trimmed.split(/\r?\n/);
+    const hasPropertyLine = lines.some((line) => {
+        const t = line.trim();
+        return t && !t.startsWith("#") && t.includes("=");
+    });
+
+    if (hasPropertyLine) {
+        return formatCode(connectorType, "properties-file", trimmed);
+    }
+
+    throw new Error("Unable to auto-detect format. Please provide valid JSON or Properties format.");
 }
 
 


### PR DESCRIPTION
…ination creation

<!-- Make sure all your commits are signed before submitting your pull request -->
<!-- Run `git commit -s` to sign off your commits to satisfy the DCO check -->
<!-- Ensure your commit messages start with your GitHub issue, e.g., debezium/dbz#<issue_number> -->
Fixes debezium/dbz#2385

## Description
<!-- Briefly describe your changes here. -->
### Description
This PR restores and improves the **Smart Editor** (Code Editor) in the Source and Destination creation flows, addressing issue #2385. The choice of editor is now driven entirely from the catalog page (selecting a card goes to the Form Editor, while clicking "Create using smart editor" opens the Code Editor directly).

### Changes
1. **Source & Destination Creation Flows**:
   - Integrated the PatternFly `@patternfly/react-code-editor` component in both [`CreateSource.tsx`](file:///wsl.localhost/Ubuntu/home/mohnish/debezium-platform/debezium-platform-stage/src/pages/Source/CreateSource.tsx) and [`CreateDestination.tsx`](file:///wsl.localhost/Ubuntu/home/mohnish/debezium-platform/debezium-platform-stage/src/pages/Destination/CreateDestination.tsx).
   - Added configuration format selectors to support **Raw JSON**, **Kafka Connect**, and **Debezium Server Properties**.
   - Implemented typing-safe format translation (conversions trigger only on explicit format button toggling or submit, ensuring typing inside Monaco is completely smooth and does not reset the cursor).
2. **Helper Utilities**:
   - Updated `formatCode` inside [`formatCodeUtils.ts`](file:///wsl.localhost/Ubuntu/home/mohnish/debezium-platform/debezium-platform-stage/src/utils/formatCodeUtils.ts) to correctly extract and map `name` and `description` from properties configuration inputs, keeping inner connector properties clean.
   - Added test coverage verifying properties extraction in [`formatCodeUtils.test.ts`](file:///wsl.localhost/Ubuntu/home/mohnish/debezium-platform/debezium-platform-stage/src/utils/formatCodeUtils.test.ts).

### Testing & Verification
- **Unit Tests**: Verified formatCode utility behaviors with `npm run test` (all tests passed).
- **Production Build**: Verified that `npm run build` completes successfully without any TypeScript or bundler errors.
- **Manual Verification**: Verified locally that toggling formats converts the parameters successfully and that save submissions successfully create the connectors on the backend.
## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [X] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [X] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [X] One feature/change per PR unless tightly coupled
- [X] Do a rebase on upstream `main`
<img width="1527" height="747" alt="image" src="https://github.com/user-attachments/assets/7ead98a9-9bf7-446d-ab57-734ae42635ce" />
<img width="1472" height="453" alt="image" src="https://github.com/user-attachments/assets/737beba8-c869-4ed2-9b4c-125cd44318c7" />
