### PR TITLE
Revert "[ci] Bump com.squareup.okhttp3:mockwebserver from 5.3.2 to 5.5.0 in /debezium-platform-conductor"

### DIFF
--- a/debezium-platform-conductor/pom.xml
+++ b/debezium-platform-conductor/pom.xml
@@ -43,7 +43,7 @@
         <version.smallrye-open-api-core>4.3.5</version.smallrye-open-api-core>
         <version.blaze-persistence>1.6.20</version.blaze-persistence>
         <version.test-containers>2.0.5</version.test-containers>
-        <version.mockwebserver>5.5.0</version.mockwebserver>
+        <version.mockwebserver>5.3.2</version.mockwebserver>
         <version.infinispan>16.1.3</version.infinispan>
         <version.pravega>0.13.0</version.pravega>
         <version.google.cloud.pubsub>1.153.0</version.google.cloud.pubsub>


### PR DESCRIPTION
Reverts debezium/debezium-platform#508