### PR TITLE
debezium/dbz#2509 Fix flaky SshConfigWatcherServiceIT with atomic file writes

### DIFF
--- a/debezium-platform-conductor/src/test/java/io/debezium/platform/environment/host/discovery/SshConfigWatcherServiceIT.java
+++ b/debezium-platform-conductor/src/test/java/io/debezium/platform/environment/host/discovery/SshConfigWatcherServiceIT.java
@@ -9,6 +9,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.util.List;
 
 import jakarta.inject.Inject;
@@ -77,20 +79,19 @@ public class SshConfigWatcherServiceIT {
     @Test
     @Order(2)
     public void shouldDetectNewHostAddedToFile() throws IOException {
-        Files.writeString(java.nio.file.Path.of(sshConfigPath),
-                """
-                        Host db-server-1
-                            HostName 192.168.1.10
-                            User ubuntu
+        writeConfigAtomically("""
+                Host db-server-1
+                    HostName 192.168.1.10
+                    User ubuntu
 
-                        Host db-server-2
-                            HostName 192.168.1.20
-                            User deploy
+                Host db-server-2
+                    HostName 192.168.1.20
+                    User deploy
 
-                        Host db-server-3
-                            HostName 10.0.0.50
-                            User admin
-                        """);
+                Host db-server-3
+                    HostName 10.0.0.50
+                    User admin
+                """);
 
         watcherService.scheduledReconciliation();
 
@@ -108,16 +109,15 @@ public class SshConfigWatcherServiceIT {
     @Test
     @Order(3)
     public void shouldMarkRemovedHostWhenDeletedFromFile() throws IOException {
-        Files.writeString(java.nio.file.Path.of(sshConfigPath),
-                """
-                        Host db-server-1
-                            HostName 192.168.1.10
-                            User ubuntu
+        writeConfigAtomically("""
+                Host db-server-1
+                    HostName 192.168.1.10
+                    User ubuntu
 
-                        Host db-server-3
-                            HostName 10.0.0.50
-                            User admin
-                        """);
+                Host db-server-3
+                    HostName 10.0.0.50
+                    User admin
+                """);
 
         watcherService.scheduledReconciliation();
 
@@ -137,5 +137,19 @@ public class SshConfigWatcherServiceIT {
                 .get()
                 .extracting(HostStatus::getProvisioningStatus)
                 .isEqualTo(ProvisioningStatus.REMOVED);
+    }
+
+    /**
+     * Writes the SSH config content atomically — write to a temp file first,
+     * then move into place. This prevents background threads (WatchService
+     * watcher, @Scheduled fallback) from reading a partially written or
+     * empty file during the truncate-then-write window of
+     * {@link Files#writeString}.
+     */
+    private void writeConfigAtomically(String content) throws IOException {
+        Path target = Path.of(sshConfigPath);
+        Path tmp = Files.createTempFile(target.getParent(), "config", ".tmp");
+        Files.writeString(tmp, content);
+        Files.move(tmp, target, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
     }
 }


### PR DESCRIPTION
Fixes debezium/dbz#2509

## Description

`SshConfigWatcherServiceIT.shouldMarkRemovedHostWhenDeletedFromFile` fails intermittently on loaded CI runs ([debezium/debezium#7848](https://github.com/debezium/debezium/actions/runs/32216990521/job/95962869727?pr=7848)). The test modifies the SSH config file using `Files.writeString()`, which truncates the file before rewriting it. On a loaded machine, the background `WatchService` watcher can read the file during this brief truncate-then-write window and see an empty or partial file, leading to incorrect reconciliation state.

The fix makes file writes in the test atomic by writing to a temporary file first, then using `Files.move()` with `ATOMIC_MOVE`. This guarantees any concurrent reader always sees a complete file.

### Changes

- Extract `writeConfigAtomically()` helper in `SshConfigWatcherServiceIT`
- Replace all `Files.writeString()` calls with the atomic helper
- Add comment explaining the motivation (per review feedback)

## PR Checklist

- [X] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [X] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [X] One feature/change per PR unless tightly coupled
- [X] Do a rebase on upstream `main`
