### PR TITLE
debezium/dbz#2271: Add validation for fully qualified table names in signal table data verification

### DIFF
--- a/debezium-platform-conductor/src/main/java/io/debezium/platform/api/SourceResource.java
+++ b/debezium-platform-conductor/src/main/java/io/debezium/platform/api/SourceResource.java
@@ -105,6 +105,7 @@ public class SourceResource {
 
     @Operation(summary = "Verify that signal data collection is configured correctly")
     @APIResponse(responseCode = "200", content = @Content(mediaType = APPLICATION_JSON, schema = @Schema(implementation = SignalDataCollectionVerifyResponse.class, type = SchemaType.OBJECT)))
+    @APIResponse(responseCode = "400", description = "Invalid request, the connection id and the fully qualified table name are both required", content = @Content(mediaType = APPLICATION_JSON, schema = @Schema(type = SchemaType.OBJECT)))
     @POST
     @Path("/signals/verify")
     public Response verifySignalConfiguration(@NotNull @Valid SignalCollectionVerifyRequest request) {

--- a/debezium-platform-conductor/src/main/java/io/debezium/platform/data/dto/SignalCollectionVerifyRequest.java
+++ b/debezium-platform-conductor/src/main/java/io/debezium/platform/data/dto/SignalCollectionVerifyRequest.java
@@ -5,7 +5,10 @@
  */
 package io.debezium.platform.data.dto;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
 public record SignalCollectionVerifyRequest(
-        Long connectionId,
-        String fullyQualifiedTableName) {
+        @NotNull Long connectionId,
+        @NotBlank String fullyQualifiedTableName) {
 }

--- a/debezium-platform-conductor/src/main/java/io/debezium/platform/environment/connection/source/JdbcSourceInspector.java
+++ b/debezium-platform-conductor/src/main/java/io/debezium/platform/environment/connection/source/JdbcSourceInspector.java
@@ -38,6 +38,7 @@ public class JdbcSourceInspector implements SourceInspector {
 
     private static final String SIGNAL_DATA_COLLECTION_CONFIGURED_MESSAGE = "Signal data collection correctly configured";
     private static final String SIGNAL_DATA_COLLECTION_MISS_CONFIGURED_MESSAGE = "Signal data collection not present or misconfigured";
+    private static final String SIGNAL_DATA_COLLECTION_NAME_REQUIRED_MESSAGE = "A fully qualified signal data collection name is required";
 
     private final DatabaseConnectionFactory databaseConnectionFactory;
     private final SignalDataCollectionChecker signalDataCollectionChecker;
@@ -85,11 +86,20 @@ public class JdbcSourceInspector implements SourceInspector {
     @Override
     public SignalDataCollectionVerifyResponse verifyDataCollectionStructure(Connection connection, String fullyQualifiedTableName) {
 
+        if (fullyQualifiedTableName == null || fullyQualifiedTableName.isBlank()) {
+            LOGGER.warn("Signal data collection verification requested without a table name");
+            return new SignalDataCollectionVerifyResponse(false, SIGNAL_DATA_COLLECTION_NAME_REQUIRED_MESSAGE);
+        }
+
+        var table = TableId.parse(fullyQualifiedTableName, false);
+        if (table == null) {
+            LOGGER.warn("Unable to parse signal data collection name {}", fullyQualifiedTableName);
+            return new SignalDataCollectionVerifyResponse(false, SIGNAL_DATA_COLLECTION_NAME_REQUIRED_MESSAGE);
+        }
+
         DatabaseConnectionConfiguration databaseConnectionConfiguration = DatabaseConnectionConfiguration.from(connection);
 
         try (JdbcConnection jdbcConnection = databaseConnectionFactory.create(databaseConnectionConfiguration)) {
-
-            var table = TableId.parse(fullyQualifiedTableName, false);
 
             boolean isConform = signalDataCollectionChecker.verifyTableStructure(
                     jdbcConnection.connection(),

--- a/debezium-platform-conductor/src/test/java/io/debezium/platform/api/SourceResourceIT.java
+++ b/debezium-platform-conductor/src/test/java/io/debezium/platform/api/SourceResourceIT.java
@@ -169,6 +169,37 @@ class SourceResourceIT {
                 .body("message", equalTo("Invalid resource with id: 123456"));
     }
 
+    @ParameterizedTest(name = "Verifying signals with an invalid {0} should return 400")
+    @MethodSource("invalidSignalVerifyRequests")
+    void verifySignalsWithInvalidField(String fieldName, String jsonBody) {
+        given()
+                .contentType(ContentType.JSON)
+                .body(jsonBody)
+                .when()
+                .post("api/sources/signals/verify")
+                .then()
+                .statusCode(400)
+                .body("title", is("Constraint Violation"))
+                .body("violations.field", hasItem("verifySignalConfiguration.request." + fieldName));
+    }
+
+    static Stream<Arguments> invalidSignalVerifyRequests() {
+        return Stream.of(
+                Arguments.of("fullyQualifiedTableName", """
+                        {
+                            "connectionId": 1
+                        }"""),
+                Arguments.of("fullyQualifiedTableName", """
+                        {
+                            "connectionId": 1,
+                            "fullyQualifiedTableName": "  "
+                        }"""),
+                Arguments.of("connectionId", """
+                        {
+                            "fullyQualifiedTableName": "public.debezium_signal"
+                        }"""));
+    }
+
     @ParameterizedTest(name = "Creating a source with empty {0} should return 400")
     @MethodSource("invalidSourceRequests")
     void createSourceWithInvalidField(String fieldName, String jsonBody) {

--- a/debezium-platform-conductor/src/test/java/io/debezium/platform/environment/connection/source/JdbcSourceInspectorTest.java
+++ b/debezium-platform-conductor/src/test/java/io/debezium/platform/environment/connection/source/JdbcSourceInspectorTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.platform.environment.connection.source;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import io.debezium.platform.data.dto.SignalDataCollectionVerifyResponse;
+import io.debezium.platform.data.model.ConnectionEntity;
+import io.debezium.platform.domain.views.Connection;
+import io.debezium.platform.environment.actions.SignalDataCollectionChecker;
+import io.debezium.platform.environment.connection.TestConnectionView;
+import io.debezium.platform.environment.database.DatabaseConnectionFactory;
+
+class JdbcSourceInspectorTest {
+
+    private DatabaseConnectionFactory databaseConnectionFactory;
+    private SignalDataCollectionChecker signalDataCollectionChecker;
+    private JdbcSourceInspector sourceInspector;
+
+    @BeforeEach
+    void setUp() {
+        databaseConnectionFactory = mock(DatabaseConnectionFactory.class);
+        signalDataCollectionChecker = mock(SignalDataCollectionChecker.class);
+        sourceInspector = new JdbcSourceInspector(databaseConnectionFactory, signalDataCollectionChecker);
+    }
+
+    @ParameterizedTest(name = "Verifying a signal data collection named [{0}] is rejected without contacting the database")
+    @NullSource
+    @ValueSource(strings = { "", "   " })
+    void shouldRejectMissingTableName(String fullyQualifiedTableName) {
+        Connection connection = new TestConnectionView(ConnectionEntity.Type.POSTGRESQL, Map.of());
+
+        SignalDataCollectionVerifyResponse response = sourceInspector.verifyDataCollectionStructure(connection, fullyQualifiedTableName);
+
+        assertThat(response.exists()).isFalse();
+        assertThat(response.message()).isEqualTo("A fully qualified signal data collection name is required");
+
+        verifyNoInteractions(databaseConnectionFactory, signalDataCollectionChecker);
+    }
+}

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -735,13 +735,15 @@
       },
       "SignalCollectionVerifyRequest" : {
         "type" : "object",
+        "required" : [ "connectionId", "fullyQualifiedTableName" ],
         "properties" : {
           "connectionId" : {
             "type" : "integer",
             "format" : "int64"
           },
           "fullyQualifiedTableName" : {
-            "type" : "string"
+            "type" : "string",
+            "pattern" : "\\S"
           }
         }
       },
@@ -2316,7 +2318,14 @@
             }
           },
           "400" : {
-            "description" : "Bad Request"
+            "description" : "Invalid request, the connection id and the fully qualified table name are both required",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "object"
+                }
+              }
+            }
           }
         }
       }

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -556,12 +556,16 @@ components:
           type: string
     SignalCollectionVerifyRequest:
       type: object
+      required:
+      - connectionId
+      - fullyQualifiedTableName
       properties:
         connectionId:
           type: integer
           format: int64
         fullyQualifiedTableName:
           type: string
+          pattern: \S
     SignalRequest:
       type: object
       required:
@@ -1680,7 +1684,12 @@ paths:
                   message:
                     type: string
         "400":
-          description: Bad Request
+          description: "Invalid request, the connection id and the fully qualified\
+            \ table name are both required"
+          content:
+            application/json:
+              schema:
+                type: object
   /api/sources/{id}:
     put:
       summary: Updates an existing source


### PR DESCRIPTION
<!-- Make sure all your commits are signed before submitting your pull request -->
<!-- Run `git commit -s` to sign off your commits to satisfy the DCO check -->
<!-- Ensure your commit messages start with your GitHub issue, e.g., debezium/dbz#<issue_number> -->
Fixes debezium/dbz#2271<the Debezium Issue Number>

## Description
This pull request hardens the signal data collection verification endpoint (JDBC-only) against requests that omit the fully qualified table name. POST /api/sources/signals/verify previously passed a null name through to TableId.parse, where a NullPointerException was caught and returned to the caller as HTTP 200 with the message "content" — a successful-looking response carrying a meaningless error. The key changes are rejection at the API boundary through bean validation, a defensive guard in the inspector so a parser failure can no longer be reported as a verification result, and test coverage at both layers.

## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
