### PR TITLE
debezium/dbz#2270: Add MongoDB signal data collection verification

### DIFF
--- a/debezium-platform-conductor/src/main/java/io/debezium/platform/environment/connection/source/MongoDbSourceInspector.java
+++ b/debezium-platform-conductor/src/main/java/io/debezium/platform/environment/connection/source/MongoDbSourceInspector.java
@@ -11,8 +11,11 @@ import java.util.stream.Collectors;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Named;
 
+import org.bson.Document;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.mongodb.client.model.Filters;
 
 import io.debezium.config.Configuration;
 import io.debezium.connector.mongodb.CollectionId;
@@ -33,6 +36,10 @@ public class MongoDbSourceInspector implements SourceInspector {
 
     public static final String MONGODB_CONNECTION_STRING = "connection.string";
     public static final String MONGODB_CREDENTIALS_MASKING_REGEX = "^(mongodb(?:\\+srv)?://)([^:/@]+):([^@]+)@";
+
+    private static final String SIGNAL_DATA_COLLECTION_CONFIGURED_MESSAGE = "Signal data collection correctly configured";
+    private static final String SIGNAL_DATA_COLLECTION_NOT_PRESENT_MESSAGE = "Signal data collection not present";
+    private static final String SIGNAL_DATA_COLLECTION_NAME_REQUIRED_MESSAGE = "A fully qualified signal data collection name is required";
 
     @Override
     public CollectionTree listAvailableCollections(Connection connectionConfig) {
@@ -91,9 +98,67 @@ public class MongoDbSourceInspector implements SourceInspector {
                 collections.size());
     }
 
+    /**
+     * Verifies that the signal data collection exists.
+     * <p>
+     * Unlike the relational inspectors this cannot check a structure: collections are schemaless, and a
+     * correctly configured signal collection is normally empty, so there is no document to inspect. Presence
+     * of the namespace is what can be established, and it is enough to catch the misspelled name that
+     * prompted this check.
+     */
     @Override
     public SignalDataCollectionVerifyResponse verifyDataCollectionStructure(Connection connection,
                                                                             String fullyQualifiedTableName) {
-        return new SignalDataCollectionVerifyResponse(true, "MongoDB signal data collection verification is not implemented yet");
+
+        if (fullyQualifiedTableName == null || fullyQualifiedTableName.isBlank()) {
+            LOGGER.warn("Signal data collection verification requested without a collection name");
+            return new SignalDataCollectionVerifyResponse(false, SIGNAL_DATA_COLLECTION_NAME_REQUIRED_MESSAGE);
+        }
+
+        // <databaseName>.<collectionName>, split on the FIRST dot because a collection name may itself
+        // contain dots. Returns null when there is no database part.
+        CollectionId collectionId = CollectionId.parse(fullyQualifiedTableName);
+        if (collectionId == null || collectionId.dbName().isBlank() || collectionId.name().isBlank()) {
+            LOGGER.warn("Unable to parse signal data collection name {}", fullyQualifiedTableName);
+            return new SignalDataCollectionVerifyResponse(false, SIGNAL_DATA_COLLECTION_NAME_REQUIRED_MESSAGE);
+        }
+
+        Object connectionString = connection.getConfig().get(MONGODB_CONNECTION_STRING);
+        Configuration mongoConfig = Configuration
+                .create()
+                .with("mongodb.connection.string", connectionString)
+                .build();
+
+        try (MongoDbConnection mongoDbConnection = MongoDbConnections.create(mongoConfig)) {
+
+            boolean exists = collectionExists(mongoDbConnection, collectionId);
+
+            String message = exists
+                    ? SIGNAL_DATA_COLLECTION_CONFIGURED_MESSAGE
+                    : SIGNAL_DATA_COLLECTION_NOT_PRESENT_MESSAGE;
+
+            return new SignalDataCollectionVerifyResponse(exists, message);
+        }
+        catch (Exception e) {
+            String sanitizedConnectionString = sanitizeConnectionString(connectionString);
+            LOGGER.error("Unable to verify signal data collection on {}", sanitizedConnectionString, e);
+            return new SignalDataCollectionVerifyResponse(false,
+                    String.format("Unable to verify signal data collection on %s", sanitizedConnectionString));
+        }
+    }
+
+    /**
+     * Asks the target database for that one collection rather than listing every collection in the cluster,
+     * so the answer does not depend on the connector's database and collection filters.
+     */
+    private boolean collectionExists(MongoDbConnection connection, CollectionId collectionId) {
+
+        Document collection = connection.getMongoClient()
+                .getDatabase(collectionId.dbName())
+                .listCollections()
+                .filter(Filters.eq("name", collectionId.name()))
+                .first();
+
+        return collection != null;
     }
 }

--- a/debezium-platform-conductor/src/test/java/io/debezium/platform/environment/actions/MongoDbSourceInspectorIT.java
+++ b/debezium-platform-conductor/src/test/java/io/debezium/platform/environment/actions/MongoDbSourceInspectorIT.java
@@ -14,11 +14,15 @@ import jakarta.inject.Inject;
 import jakarta.inject.Named;
 
 import org.junit.jupiter.api.Test;
-import org.testcontainers.mongodb.MongoDBContainer;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import com.mongodb.client.MongoClients;
 
 import io.debezium.platform.data.model.ConnectionEntity;
+import io.debezium.platform.domain.views.Connection;
 import io.debezium.platform.environment.connection.TestConnectionView;
 import io.debezium.platform.environment.connection.source.MongoDbSourceInspector;
 import io.debezium.platform.environment.connection.source.SourceInspectionException;
@@ -36,32 +40,28 @@ public class MongoDbSourceInspectorIT {
     SourceInspector sourceInspector;
 
     @Test
-    void listAvailableCollectionsReturnsMongoCollections() {
+    void listAvailableCollectionsReturnsMongoCollections(TestInfo testInfo) {
 
-        MongoDBContainer container = MongoDbTestResource.getMongoDBContainer();
+        String database = databaseFor(testInfo);
+        createCollection(database, "customers");
+        createCollection(database, "orders");
 
-        String connectionString = container.getReplicaSetUrl();
+        var collectionTree = sourceInspector.listAvailableCollections(mongoConnection());
 
-        try (var client = MongoClients.create(connectionString)) {
-            client.getDatabase("inventory").createCollection("customers");
-            client.getDatabase("inventory").createCollection("orders");
-        }
-
-        var connection = new TestConnectionView(ConnectionEntity.Type.MONGODB, Map.of(
-                MongoDbSourceInspector.MONGODB_CONNECTION_STRING, connectionString));
-
-        var collectionTree = sourceInspector.listAvailableCollections(connection);
-
+        // The tree covers the whole cluster, so it also holds databases the other tests created.
+        // Narrowing to this test's own database is what lets the assertions below be exact.
         assertThat(collectionTree.catalogs())
-                .anySatisfy(catalog -> {
-                    assertThat(catalog.name()).isEqualTo("inventory");
-                    assertThat(catalog.totalCollections()).isGreaterThanOrEqualTo(2);
+                .filteredOn(catalog -> catalog.name().equals(database))
+                .singleElement()
+                .satisfies(catalog -> {
+                    assertThat(catalog.totalCollections()).isEqualTo(2);
                     assertThat(catalog.schemas())
-                            .anySatisfy(schema -> {
+                            .singleElement()
+                            .satisfies(schema -> {
                                 assertThat(schema.name()).isNull();
                                 assertThat(schema.collections())
                                         .extracting("name")
-                                        .contains("customers", "orders");
+                                        .containsExactlyInAnyOrder("customers", "orders");
                             });
                 });
     }
@@ -91,18 +91,95 @@ public class MongoDbSourceInspectorIT {
     }
 
     @Test
-    void verifyDataCollectionStructureReturnsCurrentPlaceholderResponse() {
+    void verifyDataCollectionStructureFindsAnExistingCollection(TestInfo testInfo) {
 
-        MongoDBContainer container = MongoDbTestResource.getMongoDBContainer();
+        String database = databaseFor(testInfo);
+        createCollection(database, "debezium_signal");
 
-        String connectionString = container.getReplicaSetUrl();
+        var result = sourceInspector.verifyDataCollectionStructure(mongoConnection(), database + ".debezium_signal");
+
+        assertThat(result.exists()).isTrue();
+        assertThat(result.message()).isEqualTo("Signal data collection correctly configured");
+    }
+
+    @Test
+    void verifyDataCollectionStructureReportsAMissingCollection(TestInfo testInfo) {
+
+        String database = databaseFor(testInfo);
+        // The database exists; only the collection is absent.
+        createCollection(database, "shipments");
+
+        var result = sourceInspector.verifyDataCollectionStructure(mongoConnection(), database + ".no_such_collection");
+
+        assertThat(result.exists()).isFalse();
+        assertThat(result.message()).isEqualTo("Signal data collection not present");
+    }
+
+    @Test
+    void verifyDataCollectionStructureReportsAMisspelledDatabase(TestInfo testInfo) {
+
+        String database = databaseFor(testInfo);
+        createCollection(database, "debezium_signal");
+
+        // The false positive from dbz#2270: the collection exists, but under a database whose
+        // name was mistyped — here by dropping its last character.
+        String misspelled = database.substring(0, database.length() - 1);
+
+        var result = sourceInspector.verifyDataCollectionStructure(mongoConnection(), misspelled + ".debezium_signal");
+
+        assertThat(result.exists()).isFalse();
+        assertThat(result.message()).isEqualTo("Signal data collection not present");
+    }
+
+    @ParameterizedTest(name = "A signal data collection named [{0}] is rejected")
+    @NullSource
+    @ValueSource(strings = { "", "   ", "debezium_signal", ".debezium_signal", "ecommerce.", " .debezium_signal", "ecommerce. " })
+    void verifyDataCollectionStructureRejectsAnUnusableName(String fullyQualifiedTableName) {
+
+        var result = sourceInspector.verifyDataCollectionStructure(mongoConnection(), fullyQualifiedTableName);
+
+        assertThat(result.exists()).isFalse();
+        assertThat(result.message()).isEqualTo("A fully qualified signal data collection name is required");
+    }
+
+    @Test
+    void verifyDataCollectionStructureDoesNotLeakCredentialsWhenConnectionFails() {
+        String password = "super-secret-password";
+        String connectionString = "mongodb://admin:%s@localhost:1/?serverSelectionTimeoutMS=2000".formatted(password);
 
         var connection = new TestConnectionView(ConnectionEntity.Type.MONGODB, Map.of(
                 MongoDbSourceInspector.MONGODB_CONNECTION_STRING, connectionString));
 
-        var result = sourceInspector.verifyDataCollectionStructure(connection, "inventory.customers");
+        var result = sourceInspector.verifyDataCollectionStructure(connection, "ecommerce.debezium_signal");
 
-        assertThat(result.exists()).isTrue();
-        assertThat(result.message()).isEqualTo("MongoDB signal data collection verification is not implemented yet");
+        assertThat(result.exists()).isFalse();
+        // Asserted in full rather than as "does not contain the password": a fixed message would
+        // satisfy that trivially, and this fails loudly if the masking ever regresses.
+        assertThat(result.message())
+                .isEqualTo("Unable to verify signal data collection on mongodb://admin:****@localhost:1/?serverSelectionTimeoutMS=2000");
+        assertThat(result.message()).doesNotContain(password);
+    }
+
+    private Connection mongoConnection() {
+        return new TestConnectionView(ConnectionEntity.Type.MONGODB, Map.of(
+                MongoDbSourceInspector.MONGODB_CONNECTION_STRING,
+                MongoDbTestResource.getMongoDBContainer().getReplicaSetUrl()));
+    }
+
+    private void createCollection(String database, String collection) {
+        try (var client = MongoClients.create(MongoDbTestResource.getMongoDBContainer().getReplicaSetUrl())) {
+            client.getDatabase(database).createCollection(collection);
+        }
+    }
+
+    /**
+     * A database of its own per test. The container is shared by the whole class and nothing drops
+     * what a test creates, so a name derived from the test method is what keeps these independent
+     * of each other and of the order they run in. MongoDB caps a database name at 63 bytes and
+     * these method names are long, so only the tail — the part that differs — is kept.
+     */
+    private static String databaseFor(TestInfo testInfo) {
+        String method = testInfo.getTestMethod().orElseThrow().getName().toLowerCase();
+        return "it_" + method.substring(Math.max(0, method.length() - 40));
     }
 }


### PR DESCRIPTION
<!-- Make sure all your commits are signed before submitting your pull request -->
<!-- Run `git commit -s` to sign off your commits to satisfy the DCO check -->
<!-- Ensure your commit messages start with your GitHub issue, e.g., debezium/dbz#<issue_number> -->
Fixes debezium/dbz#2270

## Description
 MongoDbSourceInspector.verifyDataCollectionStructure replaces the exists = true stub with a real namespace check: parse via CollectionId.parse + blank guards, targeted listCollections().filter(name) on the one database, sanitized fixed message on failure. IT rewritten — 15 tests, one database per test.

Tested with the jbang cli:
```
# debezium source verify-signals --connection=1 --table=ecommerc.debezium_signal
Signal collection table is not available — Signal data collection not present

# debezium source verify-signals --connection=1 --table=ecommerce.debezium_signal
Signal collection table is available (ecommerce.debezium_signal). — Signal data collection correctly configured
```

## PR Checklist
<!-- Please review the following checklist and mark items with an 'x' before submitting your pull request. -->
- [x] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md) and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
