### PR TITLE
debezium/dbz#1094 Add connection validator for RocketMQ

### DIFF
--- a/debezium-platform-conductor/pom.xml
+++ b/debezium-platform-conductor/pom.xml
@@ -56,6 +56,7 @@
         <version.oras>0.6.4</version.oras>
         <version.rabbitmq>5.35.0</version.rabbitmq>
         <version.milvus>2.6.4</version.milvus>
+        <version.rocketmq>5.3.1</version.rocketmq>
 
         <format.formatter.goal>format</format.formatter.goal>
         <format.imports.goal>sort</format.imports.goal>
@@ -557,6 +558,22 @@
             <groupId>com.rabbitmq</groupId>
             <artifactId>amqp-client</artifactId>
             <version>${version.rabbitmq}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.rocketmq</groupId>
+            <artifactId>rocketmq-client</artifactId>
+            <version>${version.rocketmq}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.rocketmq</groupId>
+            <artifactId>rocketmq-acl</artifactId>
+            <version>${version.rocketmq}</version>
+        </dependency>
+        <!-- rocketmq-client 5.3.1 declares an older rocketmq-remoting, pin it to the client version -->
+        <dependency>
+            <groupId>org.apache.rocketmq</groupId>
+            <artifactId>rocketmq-remoting</artifactId>
+            <version>${version.rocketmq}</version>
         </dependency>
 
         <dependency>

--- a/debezium-platform-conductor/src/main/java/io/debezium/platform/environment/connection/destination/RocketMqConnectionValidator.java
+++ b/debezium-platform-conductor/src/main/java/io/debezium/platform/environment/connection/destination/RocketMqConnectionValidator.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.platform.environment.connection.destination;
+
+import java.time.Duration;
+import java.util.Map;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Named;
+
+import org.apache.rocketmq.acl.common.AclClientRPCHook;
+import org.apache.rocketmq.acl.common.SessionCredentials;
+import org.apache.rocketmq.client.producer.DefaultMQProducer;
+import org.apache.rocketmq.remoting.RPCHook;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.debezium.platform.data.dto.ConnectionValidationResult;
+import io.debezium.platform.domain.views.Connection;
+import io.debezium.platform.environment.connection.ConnectionConfigUtils;
+import io.debezium.platform.environment.connection.ConnectionValidator;
+import io.debezium.util.Strings;
+
+/**
+ * Implementation of {@link ConnectionValidator} for Apache RocketMQ connections.
+ * <p>
+ * The validation is performed against the RocketMQ name server, which is the entry point
+ * used by the Debezium Server RocketMQ sink. Connectivity is verified by issuing a topic
+ * list request, which forces an actual round trip to the name server.
+ * </p>
+ *
+ * <p>
+ * The validation process includes:
+ * <ul>
+ *   <li>Name server address presence check</li>
+ *   <li>ACL credentials consistency check, when ACL is enabled</li>
+ *   <li>Name server reachability and, when ACL is enabled, credentials verification</li>
+ * </ul>
+ * </p>
+ */
+@Named("APACHE_ROCKETMQ")
+@ApplicationScoped
+public class RocketMqConnectionValidator implements ConnectionValidator {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(RocketMqConnectionValidator.class);
+
+    private static final String NAME_SRV_ADDR = "producer.name.srv.addr";
+    private static final String PRODUCER_GROUP = "producer.group";
+    private static final String ACL_ENABLED = "producer.acl.enabled";
+    private static final String ACCESS_KEY = "producer.access.key";
+    private static final String SECRET_KEY = "producer.secret.key";
+
+    private static final String DEFAULT_PRODUCER_GROUP = "debezium";
+
+    private final int defaultConnectionTimeoutSeconds;
+
+    public RocketMqConnectionValidator(@ConfigProperty(name = "destinations.rocketmq.connection.timeout", defaultValue = "60") int defaultConnectionTimeoutSeconds) {
+        this.defaultConnectionTimeoutSeconds = defaultConnectionTimeoutSeconds;
+    }
+
+    @Override
+    public ConnectionValidationResult validate(Connection connectionConfig) {
+        if (connectionConfig == null) {
+            return ConnectionValidationResult.failed("Connection configuration cannot be null");
+        }
+
+        LOGGER.debug("Starting RocketMQ connection validation for connection: {}", connectionConfig.getName());
+
+        Map<String, Object> config = connectionConfig.getConfig();
+        String nameSrvAddr = ConnectionConfigUtils.getString(config, NAME_SRV_ADDR);
+
+        if (Strings.isNullOrBlank(nameSrvAddr)) {
+            return ConnectionValidationResult.failed("Name server address must be specified");
+        }
+
+        boolean aclEnabled = ConnectionConfigUtils.getBoolean(config, ACL_ENABLED, false);
+        String accessKey = ConnectionConfigUtils.getString(config, ACCESS_KEY);
+        String secretKey = ConnectionConfigUtils.getString(config, SECRET_KEY);
+
+        if (aclEnabled && (Strings.isNullOrBlank(accessKey) || Strings.isNullOrBlank(secretKey))) {
+            return ConnectionValidationResult.failed("Access key and secret key must be specified when ACL is enabled");
+        }
+
+        String producerGroup = ConnectionConfigUtils.getString(config, PRODUCER_GROUP);
+        if (Strings.isNullOrBlank(producerGroup)) {
+            producerGroup = DEFAULT_PRODUCER_GROUP;
+        }
+
+        RPCHook rpcHook = aclEnabled ? new AclClientRPCHook(new SessionCredentials(accessKey, secretKey)) : null;
+
+        return performConnectionValidation(nameSrvAddr, producerGroup, rpcHook);
+    }
+
+    /**
+     * Performs the actual connection validation by starting a producer against the given
+     * name server and requesting the topic list from it.
+     *
+     * @param nameSrvAddr the RocketMQ name server address list
+     * @param producerGroup the producer group used to identify the client
+     * @param rpcHook the ACL hook to sign the requests with, or {@code null} when ACL is disabled
+     * @return ConnectionValidationResult indicating success or failure
+     */
+    private ConnectionValidationResult performConnectionValidation(String nameSrvAddr, String producerGroup, RPCHook rpcHook) {
+        int timeoutMillis = (int) Duration.ofSeconds(defaultConnectionTimeoutSeconds).toMillis();
+
+        DefaultMQProducer producer = new DefaultMQProducer(producerGroup, rpcHook);
+        producer.setNamesrvAddr(nameSrvAddr);
+        producer.setMqClientApiTimeout(timeoutMillis);
+
+        try {
+            producer.start();
+
+            LOGGER.debug("Requesting topic list from RocketMQ name server at {}", nameSrvAddr);
+            producer.getDefaultMQProducerImpl()
+                    .getmQClientFactory()
+                    .getMQClientAPIImpl()
+                    .getTopicListFromNameServer(timeoutMillis);
+
+            LOGGER.debug("Successfully connected to RocketMQ name server at {}", nameSrvAddr);
+            return ConnectionValidationResult.successful();
+        }
+        catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            LOGGER.warn("RocketMQ connection validation was interrupted", e);
+            return ConnectionValidationResult.failed("Connection validation was interrupted");
+        }
+        catch (Exception e) {
+            LOGGER.warn("Failed to connect to RocketMQ name server at {}", nameSrvAddr, e);
+            return ConnectionValidationResult.failed("Failed to connect to RocketMQ name server at " + nameSrvAddr + ": " + e.getMessage());
+        }
+        finally {
+            try {
+                producer.shutdown();
+            }
+            catch (Exception e) {
+                LOGGER.warn("Error shutting down RocketMQ producer", e);
+            }
+        }
+    }
+}

--- a/debezium-platform-conductor/src/main/resources/application.yml
+++ b/debezium-platform-conductor/src/main/resources/application.yml
@@ -105,6 +105,9 @@ destinations:
   milvus:
     connection:
       timeout: 60
+  rocketmq:
+    connection:
+      timeout: 60
       
 quarkus:
   smallrye-openapi:

--- a/debezium-platform-conductor/src/main/resources/connection-schemas.json
+++ b/debezium-platform-conductor/src/main/resources/connection-schemas.json
@@ -641,5 +641,41 @@
         }
       }
     }
+  },
+  {
+    "type": "ROCKETMQ",
+    "schema": {
+      "title": "Apache RocketMQ connection properties",
+      "description": "Properties required to connect to an Apache RocketMQ name server, including optional ACL authentication",
+      "type": "object",
+      "required": [
+        "producer.name.srv.addr"
+      ],
+      "additionalProperties": {
+        "type": "string"
+      },
+      "properties": {
+        "producer.name.srv.addr": {
+          "type": "string",
+          "title": "RocketMQ name server address list (e.g. localhost:9876)"
+        },
+        "producer.group": {
+          "type": "string",
+          "title": "Producer group used by the sink"
+        },
+        "producer.acl.enabled": {
+          "type": "boolean",
+          "title": "Enable ACL authentication for the connection"
+        },
+        "producer.access.key": {
+          "type": "string",
+          "title": "Access key used when ACL is enabled"
+        },
+        "producer.secret.key": {
+          "type": "string",
+          "title": "Secret key used when ACL is enabled"
+        }
+      }
+    }
   }
 ]

--- a/debezium-platform-conductor/src/test/java/io/debezium/platform/environment/connection/ConnectionValidatorFactoryTest.java
+++ b/debezium-platform-conductor/src/test/java/io/debezium/platform/environment/connection/ConnectionValidatorFactoryTest.java
@@ -42,4 +42,10 @@ class ConnectionValidatorFactoryTest {
         ConnectionValidator validator = factory.getValidator(ConnectionEntity.Type.AZURE_EVENTS_HUBS.name());
         assertFalse(validator.validate(new TestConnectionView(ConnectionEntity.Type.AZURE_EVENTS_HUBS, Map.of())).valid());
     }
+
+    @Test
+    void shouldReturnRocketMqValidator() {
+        ConnectionValidator validator = factory.getValidator(ConnectionEntity.Type.APACHE_ROCKETMQ.name());
+        assertFalse(validator.validate(new TestConnectionView(ConnectionEntity.Type.APACHE_ROCKETMQ, Map.of())).valid());
+    }
 }

--- a/debezium-platform-conductor/src/test/java/io/debezium/platform/environment/connection/RocketMqConnectionValidatorIT.java
+++ b/debezium-platform-conductor/src/test/java/io/debezium/platform/environment/connection/RocketMqConnectionValidatorIT.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.platform.environment.connection;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import io.debezium.platform.data.dto.ConnectionValidationResult;
+import io.debezium.platform.data.model.ConnectionEntity;
+import io.debezium.platform.domain.views.Connection;
+import io.debezium.platform.environment.connection.destination.RocketMqConnectionValidator;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+@QuarkusTestResource(RocketMqTestResource.class)
+class RocketMqConnectionValidatorIT {
+
+    private static final int DEFAULT_TIMEOUT_SECONDS = 30;
+
+    private RocketMqConnectionValidator validator;
+
+    @BeforeEach
+    void setUp() {
+        validator = new RocketMqConnectionValidator(DEFAULT_TIMEOUT_SECONDS);
+    }
+
+    @Test
+    @DisplayName("Should validate connection with valid RocketMQ configuration")
+    void shouldValidateSuccessfulConnection() {
+        Map<String, Object> config = new HashMap<>();
+        config.put("producer.name.srv.addr", RocketMqTestResource.getNameServerAddress());
+        config.put("producer.group", "debezium-validation");
+
+        Connection connection = new TestConnectionView(ConnectionEntity.Type.APACHE_ROCKETMQ, config);
+
+        ConnectionValidationResult result = validator.validate(connection);
+
+        assertTrue(result.valid(), "Connection validation should succeed");
+    }
+
+    @Test
+    @DisplayName("Should validate connection when no producer group is configured")
+    void shouldValidateSuccessfulConnectionWithoutProducerGroup() {
+        Map<String, Object> config = new HashMap<>();
+        config.put("producer.name.srv.addr", RocketMqTestResource.getNameServerAddress());
+
+        Connection connection = new TestConnectionView(ConnectionEntity.Type.APACHE_ROCKETMQ, config);
+
+        ConnectionValidationResult result = validator.validate(connection);
+
+        assertTrue(result.valid(), "Connection validation should succeed with the default producer group");
+    }
+
+    @Test
+    @DisplayName("Should fail validation when the name server is unreachable")
+    void shouldFailWhenNameServerUnreachable() {
+        Map<String, Object> config = new HashMap<>();
+        config.put("producer.name.srv.addr", RocketMqTestResource.getContainer().getHost() + ":1");
+        config.put("producer.group", "debezium-validation");
+
+        Connection connection = new TestConnectionView(ConnectionEntity.Type.APACHE_ROCKETMQ, config);
+
+        ConnectionValidationResult result = validator.validate(connection);
+
+        assertFalse(result.valid(), "Validation must fail when the name server is unreachable");
+    }
+}

--- a/debezium-platform-conductor/src/test/java/io/debezium/platform/environment/connection/RocketMqConnectionValidatorTest.java
+++ b/debezium-platform-conductor/src/test/java/io/debezium/platform/environment/connection/RocketMqConnectionValidatorTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.platform.environment.connection;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import io.debezium.platform.data.dto.ConnectionValidationResult;
+import io.debezium.platform.data.model.ConnectionEntity;
+import io.debezium.platform.domain.views.Connection;
+import io.debezium.platform.environment.connection.destination.RocketMqConnectionValidator;
+
+/**
+ * Unit tests for {@link RocketMqConnectionValidator}.
+ *
+ * <p>These tests cover the parameter validation and error handling performed before any
+ * network interaction takes place, so they do not require Docker or a running RocketMQ
+ * name server. Connectivity itself is covered by {@code RocketMqConnectionValidatorIT}.</p>
+ */
+class RocketMqConnectionValidatorTest {
+
+    private static final int DEFAULT_TIMEOUT_SECONDS = 5;
+
+    private RocketMqConnectionValidator validator;
+
+    @BeforeEach
+    void setUp() {
+        validator = new RocketMqConnectionValidator(DEFAULT_TIMEOUT_SECONDS);
+    }
+
+    @Test
+    @DisplayName("Should fail validation when the connection is null")
+    void shouldFailWhenConnectionIsNull() {
+        ConnectionValidationResult result = validator.validate(null);
+
+        assertThat(result.valid()).isFalse();
+        assertThat(result.message()).isEqualTo("Connection configuration cannot be null");
+    }
+
+    @Test
+    @DisplayName("Should fail validation when name server address is missing")
+    void shouldFailWhenNameServerAddressMissing() {
+        ConnectionValidationResult result = validator.validate(connectionWith(new HashMap<>()));
+
+        assertThat(result.valid()).isFalse();
+        assertThat(result.message()).isEqualTo("Name server address must be specified");
+    }
+
+    @Test
+    @DisplayName("Should fail validation when name server address is blank")
+    void shouldFailWhenNameServerAddressIsBlank() {
+        Map<String, Object> config = new HashMap<>();
+        config.put("producer.name.srv.addr", "   ");
+
+        ConnectionValidationResult result = validator.validate(connectionWith(config));
+
+        assertThat(result.valid()).isFalse();
+        assertThat(result.message()).isEqualTo("Name server address must be specified");
+    }
+
+    @Test
+    @DisplayName("Should fail validation when ACL is enabled without credentials")
+    void shouldFailWhenAclEnabledWithoutCredentials() {
+        Map<String, Object> config = new HashMap<>();
+        config.put("producer.name.srv.addr", "localhost:9876");
+        config.put("producer.acl.enabled", true);
+
+        ConnectionValidationResult result = validator.validate(connectionWith(config));
+
+        assertThat(result.valid()).isFalse();
+        assertThat(result.message()).isEqualTo("Access key and secret key must be specified when ACL is enabled");
+    }
+
+    @Test
+    @DisplayName("Should fail validation when ACL is enabled with only an access key")
+    void shouldFailWhenAclEnabledWithoutSecretKey() {
+        Map<String, Object> config = new HashMap<>();
+        config.put("producer.name.srv.addr", "localhost:9876");
+        config.put("producer.acl.enabled", "true");
+        config.put("producer.access.key", "accessKey");
+
+        ConnectionValidationResult result = validator.validate(connectionWith(config));
+
+        assertThat(result.valid()).isFalse();
+        assertThat(result.message()).isEqualTo("Access key and secret key must be specified when ACL is enabled");
+    }
+
+    @Test
+    @DisplayName("Should fail validation when the name server is unreachable")
+    void shouldFailWhenNameServerIsUnreachable() {
+        Map<String, Object> config = new HashMap<>();
+        config.put("producer.name.srv.addr", "10.255.255.1:9876");
+
+        ConnectionValidationResult result = validator.validate(connectionWith(config));
+
+        assertThat(result.valid()).isFalse();
+        assertThat(result.message()).startsWith("Failed to connect to RocketMQ name server at 10.255.255.1:9876");
+    }
+
+    private Connection connectionWith(Map<String, Object> config) {
+        return new TestConnectionView(ConnectionEntity.Type.APACHE_ROCKETMQ, config);
+    }
+}

--- a/debezium-platform-conductor/src/test/java/io/debezium/platform/environment/connection/RocketMqTestResource.java
+++ b/debezium-platform-conductor/src/test/java/io/debezium/platform/environment/connection/RocketMqTestResource.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.platform.environment.connection;
+
+import java.util.Map;
+
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.utility.DockerImageName;
+
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
+
+public class RocketMqTestResource implements QuarkusTestResourceLifecycleManager {
+
+    private static final int NAME_SERVER_PORT = 9876;
+
+    private static final String ROCKETMQ_VERSION = "5.3.1";
+    private static final String ROCKETMQ_IMAGE = "mirror.gcr.io/apache/rocketmq:" + ROCKETMQ_VERSION;
+
+    private static final GenericContainer<?> ROCKETMQ = new GenericContainer<>(
+            DockerImageName.parse(ROCKETMQ_IMAGE))
+            .withCommand("sh", "mqnamesrv")
+            .withExposedPorts(NAME_SERVER_PORT)
+            .waitingFor(Wait.forLogMessage(".*The Name Server boot success.*", 1));
+
+    public static GenericContainer<?> getContainer() {
+        return ROCKETMQ;
+    }
+
+    public static String getNameServerAddress() {
+        return ROCKETMQ.getHost() + ":" + ROCKETMQ.getMappedPort(NAME_SERVER_PORT);
+    }
+
+    @Override
+    public Map<String, String> start() {
+        ROCKETMQ.start();
+        return Map.of();
+    }
+
+    @Override
+    public void stop() {
+        ROCKETMQ.stop();
+    }
+}


### PR DESCRIPTION
Fixes debezium/dbz#1094

## This PR

Adds ConnectionValidator for Apache RocketMQ, allowing for validation of RocketMQ destinations via UI.

### Added

- `RocketMqConnectionValidator` (`@Named("APACHE_ROCKETMQ")`) - validation is done against the RocketMQ name server; that is, the one which Debezium Server RocketMQ sink connects to.
- `ROCKETMQ` in `connection-schemas.json` to render the connection form.
- `destinations.rocketmq.connection.timeout` in `application.yml` (default 60 seconds) similar to other destinations.
- Unit tests, testcontainers-based integration test, and the case in `ConnectionValidatorFactoryTest`.

`ConnectionEntity.Type.APACHE_ROCKETMQ` already existed, therefore there were no changes to the enum.

Configuration keys are taken from Debezium Server's `RocketMqChangeConsumerConfig` directly because `PipelineMapper` uses RocketMQ connection configuration without any prefix:

| Key | Required |
|---|---|
| `producer.name.srv.addr` | yes |
| `producer.group` | no - default `debezium` |
| `producer.acl.enabled` | no |
| `producer.access.key` / `producer.secret.key` | required if ACL enabled |

**Validation process.** First the `DefaultMQProducer` is started against the configured name server, and then topic list is requested from it. Topic list request is the thing which makes real network interaction happen; `start()` method by itself doesn't connect to the name server, therefore it will show success even with unreachable server address. If ACL is used, then topic list request is signed with `AclClientRPCHook`, so invalid credentials are rejected by the server.
