### PR TITLE
debezium/dbz#1963 Allow configuring message format via source additional properties

### DIFF
--- a/debezium-platform-conductor/src/main/java/io/debezium/platform/environment/operator/PipelineMapper.java
+++ b/debezium-platform-conductor/src/main/java/io/debezium/platform/environment/operator/PipelineMapper.java
@@ -23,6 +23,8 @@ import io.debezium.operator.api.model.ConfigProperties;
 import io.debezium.operator.api.model.DebeziumServer;
 import io.debezium.operator.api.model.DebeziumServerBuilder;
 import io.debezium.operator.api.model.DebeziumServerSpecBuilder;
+import io.debezium.operator.api.model.Format;
+import io.debezium.operator.api.model.FormatType;
 import io.debezium.operator.api.model.Predicate;
 import io.debezium.operator.api.model.PredicateBuilder;
 import io.debezium.operator.api.model.Quarkus;
@@ -58,6 +60,8 @@ public class PipelineMapper {
 
     private static final String SIGNAL_ENABLED_CHANNELS_CONFIG = "signal.enabled.channels";
     private static final String NOTIFICATION_ENABLED_CHANNELS_CONFIG = "notification.enabled.channels";
+    private static final String FORMAT_CONFIG_PREFIX = "debezium.format.";
+    private static final List<String> FORMAT_PARTS = List.of("key", "value", "header");
     private static final String DEFAULT_SIGNAL_CHANNELS = "source,in-process";
     private static final String DEFAULT_NOTIFICATION_CHANNELS = "log";
     private static final String PREDICATE_PREFIX = "p";
@@ -101,7 +105,7 @@ public class PipelineMapper {
 
         var dsRuntime = createRuntime();
 
-        var dsSource = createSource(pipeline);
+        var dsSourceMapping = createSource(pipeline);
 
         var dsSink = createSink(pipeline);
 
@@ -118,8 +122,9 @@ public class PipelineMapper {
         var specBuilder = new DebeziumServerSpecBuilder()
                 .withQuarkus(dsQuarkus)
                 .withRuntime(dsRuntime)
-                .withSource(dsSource)
+                .withSource(dsSourceMapping.source())
                 .withSink(dsSink)
+                .withFormat(dsSourceMapping.format())
                 .withTransforms(transformations)
                 .withPredicates(predicates);
 
@@ -207,7 +212,15 @@ public class PipelineMapper {
                 .build();
     }
 
-    private Source createSource(PipelineFlat pipeline) {
+    /**
+     * Result of mapping a pipeline's source: the {@link Source} spec itself, plus the
+     * {@link Format} extracted from its {@code debezium.format.*} additional properties
+     * (see {@link #extractFormat(Map)}).
+     */
+    private record SourceMapping(Source source, Format format) {
+    }
+
+    private SourceMapping createSource(PipelineFlat pipeline) {
 
         var source = pipeline.getSource();
         var sourceConfig = new ConfigProperties();
@@ -219,16 +232,62 @@ public class PipelineMapper {
                     .forEach((configName, configValue) -> sourceConfig.setProps(getName(connectionType, configName, configPrefix), configValue));
         }
 
-        sourceConfig.setAllProps(source.getConfig());
+        Map<String, Object> additionalProperties = new HashMap<>(source.getConfig());
+        Format dsFormat = extractFormat(additionalProperties);
+
+        sourceConfig.setAllProps(additionalProperties);
         sourceConfig.setProps(SIGNAL_ENABLED_CHANNELS_CONFIG, DEFAULT_SIGNAL_CHANNELS);
         sourceConfig.setProps(NOTIFICATION_ENABLED_CHANNELS_CONFIG, DEFAULT_NOTIFICATION_CHANNELS);
 
-        return new SourceBuilder()
+        var dsSource = new SourceBuilder()
                 .withSourceClass(source.getType())
                 .withOffset(getOffset(pipeline))
                 .withSchemaHistory(getSchemaHistory(pipeline))
                 .withConfig(sourceConfig)
                 .build();
+
+        return new SourceMapping(dsSource, dsFormat);
+    }
+
+    /**
+     * Extracts {@code debezium.format.(key|value|header)} and
+     * {@code debezium.format.(key|value|header).*} entries from the source's additional
+     * properties into a {@link Format}, removing them from {@code additionalProperties} so
+     * they are not also emitted under {@code debezium.source.*} (see debezium/dbz#1963).
+     *
+     * <p>This is an interim solution: it lets users configure the message format (e.g. Avro
+     * with a schema registry, or disabling the JSON schema envelope) per-pipeline today,
+     * through the source's additional properties, until format becomes a first-class,
+     * reusable resource of its own.
+     */
+    private static Format extractFormat(Map<String, Object> additionalProperties) {
+        var format = new Format();
+        Map<String, FormatType> formatTypesByPart = Map.of(
+                "key", format.getKey(),
+                "value", format.getValue(),
+                "header", format.getHeader());
+
+        for (String part : FORMAT_PARTS) {
+            FormatType formatType = formatTypesByPart.get(part);
+            String typeKey = FORMAT_CONFIG_PREFIX + part;
+            String nestedPrefix = typeKey + ".";
+
+            Object type = additionalProperties.remove(typeKey);
+            if (type != null) {
+                formatType.setType(type.toString());
+            }
+
+            additionalProperties.entrySet().removeIf(entry -> {
+                if (!entry.getKey().startsWith(nestedPrefix)) {
+                    return false;
+                }
+                String nestedKey = entry.getKey().substring(nestedPrefix.length());
+                formatType.getConfig().setProps(nestedKey, entry.getValue());
+                return true;
+            });
+        }
+
+        return format;
     }
 
     private static String getName(ConnectionEntity.Type connectionType, String configName, String configPrefix) {

--- a/debezium-platform-conductor/src/main/java/io/debezium/platform/environment/operator/PipelineMapper.java
+++ b/debezium-platform-conductor/src/main/java/io/debezium/platform/environment/operator/PipelineMapper.java
@@ -13,6 +13,7 @@ import static io.debezium.platform.environment.database.DatabaseConnectionConfig
 import static io.debezium.platform.environment.database.DatabaseConnectionFactory.DATABASE_CONNECTION_CONFIGURATION_PREFIX;
 
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -277,14 +278,15 @@ public class PipelineMapper {
                 formatType.setType(type.toString());
             }
 
-            additionalProperties.entrySet().removeIf(entry -> {
-                if (!entry.getKey().startsWith(nestedPrefix)) {
-                    return false;
+            Iterator<Map.Entry<String, Object>> iterator = additionalProperties.entrySet().iterator();
+            while (iterator.hasNext()) {
+                Map.Entry<String, Object> entry = iterator.next();
+                if (entry.getKey().startsWith(nestedPrefix)) {
+                    String nestedKey = entry.getKey().substring(nestedPrefix.length());
+                    formatType.getConfig().setProps(nestedKey, entry.getValue());
+                    iterator.remove();
                 }
-                String nestedKey = entry.getKey().substring(nestedPrefix.length());
-                formatType.getConfig().setProps(nestedKey, entry.getValue());
-                return true;
-            });
+            }
         }
 
         return format;

--- a/debezium-platform-conductor/src/test/java/io/debezium/platform/environment/operator/PipelineMapperTest.java
+++ b/debezium-platform-conductor/src/test/java/io/debezium/platform/environment/operator/PipelineMapperTest.java
@@ -236,6 +236,52 @@ public class PipelineMapperTest {
     }
 
     @Test
+    @FixFor("debezium/dbz#1963")
+    public void testMapper_ShouldExtractFormatFromSourceAdditionalProperties() {
+        var pipeline = mockPipelineWithSource(ConnectionEntity.Type.POSTGRESQL, Map.of(
+                DATABASE, "customers",
+                USERNAME, "sa"));
+        when(pipeline.getSource().getConfig()).thenReturn(Map.of(
+                "debezium.format.key", "json",
+                "debezium.format.key.schemas.enable", "false",
+                "debezium.format.value", "json",
+                "debezium.format.value.schemas.enable", "false",
+                "snapshot.mode", "when_needed"));
+
+        var result = pipelineMapper.map(pipeline);
+
+        var format = result.getSpec().getFormat();
+        assertThat(format.getKey().getType()).isEqualTo("json");
+        assertThat(format.getKey().getConfig().getProps()).containsEntry("schemas.enable", "false");
+        assertThat(format.getValue().getType()).isEqualTo("json");
+        assertThat(format.getValue().getConfig().getProps()).containsEntry("schemas.enable", "false");
+
+        assertThat(result.getSpec().getSource().getConfig().getProps())
+                .containsEntry("snapshot.mode", "when_needed")
+                .doesNotContainKeys(
+                        "debezium.format.key",
+                        "debezium.format.key.schemas.enable",
+                        "debezium.format.value",
+                        "debezium.format.value.schemas.enable");
+    }
+
+    @Test
+    @FixFor("debezium/dbz#1963")
+    public void testMapper_ShouldDefaultFormatWhenNotConfigured() {
+        var pipeline = mockPipelineWithSource(ConnectionEntity.Type.POSTGRESQL, Map.of(
+                DATABASE, "customers",
+                USERNAME, "sa"));
+
+        var result = pipelineMapper.map(pipeline);
+
+        var format = result.getSpec().getFormat();
+        assertThat(format.getKey().getType()).isEqualTo("json");
+        assertThat(format.getKey().getConfig().getProps()).isEmpty();
+        assertThat(format.getValue().getType()).isEqualTo("json");
+        assertThat(format.getValue().getConfig().getProps()).isEmpty();
+    }
+
+    @Test
     @FixFor("debezium/dbz#2112")
     public void testMapper_ShouldHandleTransformWithEmptyPredicate() {
         var pipeline = mockPipelineWithSource(ConnectionEntity.Type.POSTGRESQL, Map.of(

--- a/debezium-platform-conductor/src/test/java/io/debezium/platform/environment/operator/PipelineMapperTest.java
+++ b/debezium-platform-conductor/src/test/java/io/debezium/platform/environment/operator/PipelineMapperTest.java
@@ -238,15 +238,16 @@ public class PipelineMapperTest {
     @Test
     @FixFor("debezium/dbz#1963")
     public void testMapper_ShouldExtractFormatFromSourceAdditionalProperties() {
-        var pipeline = mockPipelineWithSource(ConnectionEntity.Type.POSTGRESQL, Map.of(
-                DATABASE, "customers",
-                USERNAME, "sa"));
-        when(pipeline.getSource().getConfig()).thenReturn(Map.of(
-                "debezium.format.key", "json",
-                "debezium.format.key.schemas.enable", "false",
-                "debezium.format.value", "json",
-                "debezium.format.value.schemas.enable", "false",
-                "snapshot.mode", "when_needed"));
+        var pipeline = mockPipelineWithSource(ConnectionEntity.Type.POSTGRESQL,
+                Map.of(
+                        DATABASE, "customers",
+                        USERNAME, "sa"),
+                Map.of(
+                        "debezium.format.key", "json",
+                        "debezium.format.key.schemas.enable", "false",
+                        "debezium.format.value", "json",
+                        "debezium.format.value.schemas.enable", "false",
+                        "snapshot.mode", "when_needed"));
 
         var result = pipelineMapper.map(pipeline);
 
@@ -322,6 +323,11 @@ public class PipelineMapperTest {
     }
 
     private PipelineFlat mockPipelineWithSource(ConnectionEntity.Type type, Map<String, Object> connectionConfig) {
+        return mockPipelineWithSource(type, connectionConfig, Map.of());
+    }
+
+    private PipelineFlat mockPipelineWithSource(ConnectionEntity.Type type, Map<String, Object> connectionConfig,
+                                                Map<String, Object> sourceConfig) {
         var pipeline = mock(PipelineFlat.class);
         var source = mock(SourceFlat.class);
         var destination = mock(DestinationFlat.class);
@@ -331,6 +337,7 @@ public class PipelineMapperTest {
         when(connection.getConfig()).thenReturn(connectionConfig);
 
         when(source.getConnection()).thenReturn(connection);
+        when(source.getConfig()).thenReturn(sourceConfig);
 
         when(pipeline.getSource()).thenReturn(source);
         when(pipeline.getDestination()).thenReturn(destination);


### PR DESCRIPTION
## Description

Conductor currently ignores any `debezium.format.*` properties passed through
a source's additional properties: `PipelineMapper#createSource` forwards the
whole `source.getConfig()` map into `spec.source.config`, which the Debezium
Server engine emits as `debezium.source.debezium.format.*` — a namespace it
never reads. There is no other way today to set `spec.format` on the
generated `DebeziumServer` CR through the Platform API/UI, even though the
CRD (and `io.debezium.operator.api.model.Format`) already support it.

This affects at least two real use cases raised in the issue:
- Configuring an Avro converter against a schema registry (original report).
- Disabling the JSON schema envelope (`schemas.enable=false`) per pipeline
  (our case).

As agreed with @mfvitale in the issue thread, this implements the proposed
interim solution: let users set `debezium.format.(key|value|header)` and
`debezium.format.(key|value|header).*` as source additional properties, and
have Conductor recognize and lift them into `spec.format` on the generated
CR — instead of forwarding them (incorrectly) into `spec.source.config`.

### Example

Given a source with additional properties:

```json
{
  "debezium.format.key": "json",
  "debezium.format.key.schemas.enable": "false",
  "debezium.format.value": "json",
  "debezium.format.value.schemas.enable": "false"
}
```

The generated `DebeziumServer` CR now gets:

```yaml
spec:
  format:
    key:
      type: json
      config:
        schemas.enable: "false"
    value:
      type: json
      config:
        schemas.enable: "false"
```

...and none of the `debezium.format.*` keys leak into `spec.source.config`
anymore.

### Implementation notes

- `PipelineMapper#createSource` now returns a `SourceMapping(Source, Format)`
  record instead of just `Source`, so `Format` can be built from the same
  additional-properties map without a second pass or an instance field on the
  (`@ApplicationScoped`, effectively shared) mapper.
- The extraction (`extractFormat`) mutates a defensive copy of the additional
  properties map, removing every matched key so it's never also emitted
  under `spec.source.config`.
- Backward compatible: when no `debezium.format.*` property is set,
  `spec.format` keeps its current default (`type: json`, empty `config`),
  same as today.
- This is intentionally scoped as the interim fix discussed in the issue,
  not the longer-term first-class/reusable Format resource idea — happy to
  help with that follow-up separately if useful.

### Testing

- `mvn compile` — builds clean.
- `mvn test -Dtest=PipelineMapperTest` — 15/15 pass, including two new tests:
  `testMapper_ShouldExtractFormatFromSourceAdditionalProperties` and
  `testMapper_ShouldDefaultFormatWhenNotConfigured`.
- `mvn test` (full `debezium-platform-conductor` module) — 268/268 pass, no
  regressions.

## PR Checklist
- [x] I have read the contribution guidelines and the governance document on PR expectations.
- [x] Minimal changes to code not directly related to your change (e.g. no unnecessary formatting changes or refactoring to existing code)
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `main`
