### PR TITLE
debezium/dbz#2167 Add snapshot event count rate panel

### DIFF
--- a/debezium-platform-conductor/src/main/resources/panels.yml
+++ b/debezium-platform-conductor/src/main/resources/panels.yml
@@ -135,3 +135,13 @@ panels:
     visualization:
       type: donut-utilization
       suggestedStep: 15s
+
+  - id: snapshot-event-count
+    title: "Snapshot Event Count Rate"
+    description: "Rate of snapshot change data capture events per second"
+    category: snapshot
+    query: 'rate(debezium_event_count_total{service_name="{{pipeline_id}}",debezium_context="snapshot",debezium_event_type="read"}[5m])'
+    unit: events/s
+    visualization:
+      type: area
+      suggestedStep: 15s


### PR DESCRIPTION
Follow-up to debezium/debezium#7896, which added the `TotalNumberOfReadEventsSeen` MBean attribute. This adds the dashboard panel that surfaces it.

This is point 4 of debezium/dbz#2167.

### What changed

Adds a `snapshot-event-count` panel to `panels.yml`, plotting the per-second rate of snapshot change data capture events:

```
rate(debezium_event_count_total{service_name="{{pipeline_id}}",debezium_context="snapshot",debezium_event_type="read"}[5m])
```

The panel uses the `area` visualization and `events/s` unit, both of which are already used by existing panels in this file.

### Depends on

debezium/debezium-server#312, which maps the MBean attribute into the JMX exporter configs. Until that ships, the metric series `debezium_event_count_total{debezium_event_type="read"}` does not exist in Prometheus and this panel renders empty. Please merge that one first.

### Why this panel is needed

Before debezium/debezium#7896 the snapshot event panels showed create, update and delete all at 0 during a snapshot, because snapshot events use `Operation.READ`, which had no dedicated counter. The only counter that moved was `TotalNumberOfEventsSeen`, a superset that cannot isolate read events without subtraction. This panel makes snapshot throughput visible directly.

### Testing

I did not run tests for this change. It is a resource-only panel definition. I confirmed `panels.yml` still parses as YAML and that the new entry matches the structure, visualization type and unit conventions of the existing panels.

### AI assistance

I used Claude to help review this diff and to confirm the visualization type and unit values against the existing panel definitions and the platform rendering code before opening it.
