### PR TITLE
debezium/dbz#2584 Fix double undeploy execution and orphaned host_deployment records

### DIFF
--- a/debezium-platform-conductor/src/main/java/io/debezium/platform/data/model/HostDeploymentEntity.java
+++ b/debezium-platform-conductor/src/main/java/io/debezium/platform/data/model/HostDeploymentEntity.java
@@ -36,8 +36,8 @@ public class HostDeploymentEntity {
     @GeneratedValue
     private Long id;
 
-    @OneToOne
-    @JoinColumn(name = "pipeline_id", unique = true, nullable = false)
+    @OneToOne(optional = true)
+    @JoinColumn(name = "pipeline_id", unique = true, nullable = true)
     private PipelineEntity pipeline;
 
     @ManyToOne

--- a/debezium-platform-conductor/src/main/java/io/debezium/platform/environment/host/HostPipelineController.java
+++ b/debezium-platform-conductor/src/main/java/io/debezium/platform/environment/host/HostPipelineController.java
@@ -104,7 +104,10 @@ public class HostPipelineController implements PipelineController {
 
     @Override
     public void undeploySync(Long pipelineId) {
-        executeUndeploy(pipelineId);
+        // The pipeline→host_deployment FK was dropped (V3.7.0.3) and the
+        // @OneToOne is optional, so pipeline deletion does not require
+        // prior host_deployment cleanup. Container teardown is handled
+        // exclusively by the outbox-driven undeploy(pipelineId).
     }
 
     @Override

--- a/debezium-platform-conductor/src/test/java/io/debezium/platform/environment/host/HostPipelineControllerTest.java
+++ b/debezium-platform-conductor/src/test/java/io/debezium/platform/environment/host/HostPipelineControllerTest.java
@@ -357,6 +357,20 @@ class HostPipelineControllerTest {
                 eq(new DeploymentRequest("test-pipeline-1", "quay.io/debezium/server:latest", 9000, "hash123")));
     }
 
+    @Test
+    void undeploySyncIsNoOp() {
+        HostDeployment deployment = mockDeployment(500L, "my-pipeline", "host-7");
+        when(deploymentService.findByPipelineId(25L)).thenReturn(Optional.of(deployment));
+
+        controller.undeploySync(25L);
+
+        // undeploySync is a no-op in host mode — container cleanup is handled
+        // exclusively by the outbox-driven undeploy()
+        verify(deploymentService, never()).deleteDeployment(anyLong());
+        verify(containerRuntime, never()).stop(anyString(), anyString());
+        verify(containerRuntime, never()).undeploy(anyString(), anyString());
+    }
+
     // ── Helpers ──
 
     private PipelineFlat buildMinimalPipeline(Long id) {


### PR DESCRIPTION
Fixes debezium/dbz#2584

## Description

In host deployment mode, pipeline deletion via the Outbox pattern triggered two separate undeploy executions:

1. `HostPipelineController.undeploySync()` ran full container cleanup   (stop + remove + DB record deletion) synchronously during the HTTP DELETE
2. The Outbox CDC event later fired `undeploy()` → `executeUndeploy()` a second time, finding no deployment record and logging a confusing message

The root cause was the `@OneToOne` mapping on `HostDeploymentEntity.pipeline` without `optional = true`, which made Hibernate generate an INNER JOIN in `findByPipelineId()`. After the pipeline row was deleted, the INNER JOIN
returned nothing — even though the `host_deployment` row still existed.

**Fix:**

Set `@OneToOne(optional = true)` and `@JoinColumn(nullable = true)` on the pipeline relationship. This makes Hibernate use a LEFT JOIN, so `findByPipelineId()` can still find the `host_deployment` row after the pipeline is deleted. With this, `undeploySync()` becomes a no-op (matching operator mode) and container cleanup is handled exclusively by the outbox-driven `executeUndeploy()` - executing exactly once.

## PR Checklist

- [X] I have read the [contribution guidelines](https://github.com/debezium/debezium/blob/main/CONTRIBUTING.md)
  and the [governance document](https://github.com/debezium/governance/blob/main/GOVERNANCE.md) on PR expectations.
- [X] Minimal changes to code not directly related to your change
- [X] One feature/change per PR
- [X] Rebased on upstream `main`
